### PR TITLE
fix(agy): resolve Gemini 3.5 Flash silent stops and missing thought signatures

### DIFF
--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -163,26 +163,7 @@ function transformRequestBody(
         injectMissingToolCallIds(contents);
 
         const latestSig = getLatestSignature(sessionId);
-
-        // Collect all function calls in chronological order
-        const allFunctionCalls: any[] = [];
-        for (const content of contents) {
-          if (content && typeof content === "object" && Array.isArray(content.parts)) {
-            for (const part of content.parts) {
-              if (part && typeof part === "object" && part.functionCall) {
-                allFunctionCalls.push(part);
-              }
-            }
-          }
-        }
-
-        // Only apply the latest signature to the VERY LAST function call
-        if (allFunctionCalls.length > 0 && latestSig) {
-          const lastFunctionCall = allFunctionCalls[allFunctionCalls.length - 1];
-          if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
-            lastFunctionCall.thoughtSignature = latestSig;
-          }
-        }
+        applyLatestSignature(contents, latestSig);
         requestPayloadInside.contents = contents;
       }
 
@@ -216,34 +197,7 @@ function transformRequestBody(
       injectMissingToolCallIds(contents);
 
       const latestSig = getLatestSignature(sessionId);
-
-      // Collect all function calls in chronological order
-      const allFunctionCalls: any[] = [];
-      for (const content of contents) {
-        if (content && typeof content === "object" && Array.isArray(content.parts)) {
-          for (const part of content.parts) {
-            if (part && typeof part === "object" && part.functionCall) {
-              allFunctionCalls.push(part);
-            }
-          }
-        }
-      }
-
-      // Only apply the latest signature to the VERY LAST function call
-      if (allFunctionCalls.length > 0 && latestSig) {
-        const lastFunctionCall = allFunctionCalls[allFunctionCalls.length - 1];
-        if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
-          lastFunctionCall.thoughtSignature = latestSig;
-        }
-      } else if (contents.length > 0 && latestSig) {
-        const lastContent = contents[contents.length - 1];
-        if (lastContent && Array.isArray(lastContent.parts) && lastContent.parts.length > 0) {
-          const lastPart = lastContent.parts[lastContent.parts.length - 1];
-          if (lastPart && typeof lastPart === "object" && !lastPart.thoughtSignature) {
-            lastPart.thoughtSignature = latestSig;
-          }
-        }
-      }
+      applyLatestSignature(contents, latestSig);
       requestPayload.contents = contents;
     }
 
@@ -540,4 +494,28 @@ function injectMissingToolCallIds(contents: any[]): void {
     }
   }
 }
+
+function applyLatestSignature(contents: any[], latestSig: string | undefined): void {
+  // Collect all function calls in chronological order
+  const allFunctionCalls: any[] = [];
+  for (const content of contents) {
+    if (content && typeof content === "object" && Array.isArray(content.parts)) {
+      for (const part of content.parts) {
+        if (part && typeof part === "object" && part.functionCall) {
+          allFunctionCalls.push(part);
+        }
+      }
+    }
+  }
+
+  // Only apply the latest signature to the VERY LAST function call
+  if (allFunctionCalls.length > 0 && latestSig) {
+    const lastFunctionCall = allFunctionCalls[allFunctionCalls.length - 1];
+    if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
+      lastFunctionCall.thoughtSignature = latestSig;
+    }
+  }
+}
+
+
 

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -235,6 +235,14 @@ function transformRequestBody(
         if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
           lastFunctionCall.thoughtSignature = latestSig;
         }
+      } else if (contents.length > 0 && latestSig) {
+        const lastContent = contents[contents.length - 1];
+        if (lastContent && Array.isArray(lastContent.parts) && lastContent.parts.length > 0) {
+          const lastPart = lastContent.parts[lastContent.parts.length - 1];
+          if (lastPart && typeof lastPart === "object" && !lastPart.thoughtSignature) {
+            lastPart.thoughtSignature = latestSig;
+          }
+        }
       }
       requestPayload.contents = contents;
     }

--- a/src/sdk/request/thinking.ts
+++ b/src/sdk/request/thinking.ts
@@ -464,11 +464,6 @@ export function deduplicateThinkingText(
 
       const filteredParts = newParts.filter((p) => p !== null);
 
-      if (filteredParts.length === 0) {
-        const { content: _ignore, ...candWithoutContent } = cand;
-        return candWithoutContent;
-      }
-
       return {
         ...cand,
         content: { ...content, parts: filteredParts },
@@ -518,8 +513,7 @@ export function deduplicateThinkingText(
 
     const filteredContent = newContent.filter((b) => b !== null);
     if (filteredContent.length === 0) {
-      const { content: _ignore, ...respWithoutContent } = resp;
-      return respWithoutContent;
+      return { ...resp, content: [] };
     }
     return { ...resp, content: filteredContent };
   }

--- a/src/sdk/request/thinking.ts
+++ b/src/sdk/request/thinking.ts
@@ -464,6 +464,11 @@ export function deduplicateThinkingText(
 
       const filteredParts = newParts.filter((p) => p !== null);
 
+      if (filteredParts.length === 0) {
+        const { content: _ignore, ...candWithoutContent } = cand;
+        return candWithoutContent;
+      }
+
       return {
         ...cand,
         content: { ...content, parts: filteredParts },
@@ -512,6 +517,10 @@ export function deduplicateThinkingText(
     });
 
     const filteredContent = newContent.filter((b) => b !== null);
+    if (filteredContent.length === 0) {
+      const { content: _ignore, ...respWithoutContent } = resp;
+      return respWithoutContent;
+    }
     return { ...resp, content: filteredContent };
   }
 
@@ -709,12 +718,17 @@ export function createStreamingTransformer(
       if (!hasSeenUsageMetadata) {
         const syntheticUsage = {
           response: {
+            candidates: [
+              {
+                finishReason: "STOP",
+              },
+            ],
             usageMetadata: {
               promptTokenCount: 0,
               candidatesTokenCount: 0,
               totalTokenCount: 0,
-            }
-          }
+            },
+          },
         };
         controller.enqueue(encoder.encode(`\ndata: ${JSON.stringify(syntheticUsage)}\n\n`));
       }


### PR DESCRIPTION

## Bug Fixes

The primary objective of this pull request is to resolve stability issues encountered with **Gemini 3.5 Flash**, specifically addressing instances where the model would stop responding without a proper termination signal. In `src/sdk/request/thinking.ts`, the `createStreamingTransformer` has been updated to inject a synthetic `finishReason` set to **STOP** within the usage metadata if a natural termination has not been observed. This ensures that the streaming controller can properly close the connection and prevents the client from hanging on an incomplete stream.

Additionally, this change hardens the `deduplicateThinkingText` logic in `src/sdk/request/thinking.ts`. The function now checks if filtering results in an empty set of parts or content blocks. If no content remains after deduplication, the code returns the response object with the `content` property omitted entirely. This prevents the transmission of malformed payloads that could trigger errors in the underlying SDK or API.

The logic within `src/sdk/request/prepare.ts` has also been refined to ensure that **thought signatures** are correctly propagated. The transformer now identifies the last part of the current content and applies the `latestSig` as the **thoughtSignature** if it is missing, even in scenarios that do not involve explicit function calls. This ensures metadata consistency across all request types and satisfies internal validation requirements for the **AGY** framework.