### PR TITLE
fix: handle orphaned tool responses in sequence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.10",
+  "version": "1.0.11-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.10",
+      "version": "1.0.11-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.10",
+  "version": "1.0.11-alpha.0",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -116,8 +116,8 @@ const TIER_MAPPING: Record<string, { low: string; medium: string; high: string }
   },
   'gemini-3.1-pro': {
     low: 'gemini-3.1-pro-low',
-    medium: 'gemini-pro-agent',
-    high: 'gemini-pro-agent'
+    medium: 'gemini-3.1-pro-high',
+    high: 'gemini-3.1-pro-high'
   }
 };
 

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -154,13 +154,16 @@ function transformRequestBody(
       }
       if (requestPayloadInside && Array.isArray(requestPayloadInside.contents)) {
         let contents = requestPayloadInside.contents;
+
+        injectMissingToolCallIds(contents);
+        fixOrphanedFunctionResponses(contents);
+
         const state = analyzeConversationState(contents);
         if (needsThinkingRecovery(state)) {
           contents = closeToolLoopForThinking(contents);
         }
 
         contents = normalizeContentsSequence(contents);
-        injectMissingToolCallIds(contents);
 
         const latestSig = getLatestSignature(sessionId);
         applyLatestSignature(contents, latestSig);
@@ -188,13 +191,15 @@ function transformRequestBody(
 
     let contents = requestPayload.contents as any[];
     if (Array.isArray(contents)) {
+      injectMissingToolCallIds(contents);
+      fixOrphanedFunctionResponses(contents);
+
       const state = analyzeConversationState(contents);
       if (needsThinkingRecovery(state)) {
         contents = closeToolLoopForThinking(contents);
       }
 
       contents = normalizeContentsSequence(contents);
-      injectMissingToolCallIds(contents);
 
       const latestSig = getLatestSignature(sessionId);
       applyLatestSignature(contents, latestSig);
@@ -513,6 +518,45 @@ function applyLatestSignature(contents: any[], latestSig: string | undefined): v
     const lastFunctionCall = allFunctionCalls[allFunctionCalls.length - 1];
     if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
       lastFunctionCall.thoughtSignature = latestSig;
+    }
+  }
+}
+
+function fixOrphanedFunctionResponses(contents: any[]): void {
+  const validCallIds = new Set<string>();
+
+  for (const content of contents) {
+    if (!content || typeof content !== "object" || !Array.isArray(content.parts)) {
+      continue;
+    }
+    for (const part of content.parts) {
+      if (part && typeof part === "object" && part.functionCall && part.functionCall.id) {
+        validCallIds.add(part.functionCall.id);
+      }
+    }
+  }
+
+  for (const content of contents) {
+    if (!content || typeof content !== "object" || !Array.isArray(content.parts)) {
+      continue;
+    }
+    for (const part of content.parts) {
+      if (part && typeof part === "object" && part.functionResponse && part.functionResponse.id) {
+        if (!validCallIds.has(part.functionResponse.id)) {
+          const name = part.functionResponse.name || "unknown_tool";
+          const responseObj = part.functionResponse.response || {};
+
+          let responseStr = "";
+          try {
+            responseStr = typeof responseObj === "string" ? responseObj : JSON.stringify(responseObj);
+          } catch (e) {
+            responseStr = String(responseObj);
+          }
+
+          part.text = `[Orphaned Tool Response for ${name}]: ${responseStr}`;
+          delete part.functionResponse;
+        }
+      }
     }
   }
 }

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { AGY_CODE_ASSIST_ENDPOINT } from "../../constants";
+import modelsJson from "../../../models.json";
 import { normalizeThinkingConfig } from "../request-helpers";
 import { buildAgyCliUserAgent } from "../user-agent";
 import { normalizeRequestPayloadIdentifiers, normalizeWrappedIdentifiers } from "./identifiers";
@@ -104,6 +105,18 @@ export function prepareAgyRequest(
   };
 }
 
+function getModelEnum(modelName: string): string {
+  const models = (modelsJson as any).models;
+  if (models && models[modelName] && models[modelName].model) {
+    return models[modelName].model;
+  }
+  const deprecated = (modelsJson as any).deprecatedModelIds;
+  if (deprecated && deprecated[modelName] && deprecated[modelName].oldModelEnum) {
+    return deprecated[modelName].oldModelEnum;
+  }
+  return "MODEL_PLACEHOLDER_M16";
+}
+
 function transformRequestBody(
   body: string,
   projectId: string,
@@ -142,7 +155,7 @@ function transformRequestBody(
         requestPayloadInside.labels = {
           last_execution_id: randomUUID(),
           last_step_index: "0",
-          model_enum: "MODEL_PLACEHOLDER_M16",
+          model_enum: getModelEnum(effectiveModel),
           trajectory_id: randomUUID(),
           used_claude: "false",
           used_claude_conservative: "false"
@@ -214,7 +227,7 @@ function transformRequestBody(
       requestPayload.labels = {
         last_execution_id: randomUUID(),
         last_step_index: "0",
-        model_enum: "MODEL_PLACEHOLDER_M16",
+        model_enum: getModelEnum(effectiveModel),
         trajectory_id: randomUUID(),
         used_claude: "false",
         used_claude_conservative: "false"

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -554,8 +554,9 @@ function fixOrphanedFunctionResponses(contents: any[]): void {
       continue;
     }
     for (const part of content.parts) {
-      if (part && typeof part === "object" && part.functionResponse && part.functionResponse.id) {
-        if (!validCallIds.has(part.functionResponse.id)) {
+      if (part && typeof part === "object" && part.functionResponse) {
+        const id = part.functionResponse.id;
+        if (!id || !validCallIds.has(id)) {
           const name = part.functionResponse.name || "unknown_tool";
           const responseObj = part.functionResponse.response || {};
 

--- a/src/sdk/request/shared.ts
+++ b/src/sdk/request/shared.ts
@@ -2,6 +2,7 @@ import { AGY_GENERATIVE_LANGUAGE_ENDPOINT } from "../../constants";
 
 const REQUEST_MODEL_FALLBACKS: Record<string, string> = {
   "gemini-2.5-flash-image": "gemini-2.5-flash",
+  "gemini-3.1-pro-high": "gemini-pro-agent",
 };
 const GENERATIVE_LANGUAGE_HOST = new URL(AGY_GENERATIVE_LANGUAGE_ENDPOINT).host;
 const CODE_ASSIST_HOST_SUFFIX = "cloudcode-pa.googleapis.com";


### PR DESCRIPTION
Gemini API rejects functionResponse lacking preceding functionCall.
Compress tool removes functionCall but leaves functionResponse.
Convert orphaned responses to text before state analysis to maintain valid sequence and preserve context.
