### PR TITLE
feat(plugin): add /agyquotasummary command and tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-alpha.0",
+  "version": "1.0.11-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.11-alpha.0",
+      "version": "1.0.11-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-alpha.0",
+  "version": "1.0.11-alpha.2",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,8 +4,9 @@ import { agyFetch } from './fetch';
 import { createOAuthAuthorizeMethod } from './plugin/oauth-authorize';
 import { accessTokenExpired, isOAuthAuth, parseRefreshParts } from './plugin/auth';
 import { resolveCachedAuth, initDiskSignatureCache } from './plugin/cache';
-import { ensureProjectContext, retrieveUserQuota } from './plugin/project';
+import { ensureProjectContext, retrieveUserQuota, retrieveUserQuotaSummary } from './plugin/project';
 import { createAgyQuotaTool, AGY_QUOTA_TOOL_NAME } from './plugin/quota';
+import { createAgyQuotaSummaryTool, AGY_QUOTA_SUMMARY_TOOL_NAME } from './plugin/quota-summary';
 import { maybeShowAgyCapacityToast, maybeShowAgyTestToast } from './plugin/notify';
 import { simulateClientBackgroundTraffic } from './plugin/traffic';
 import { buildAgyCliUserAgent } from './sdk/user-agent';
@@ -39,6 +40,13 @@ const AGY_QUOTA_COMMAND = 'agyquota';
 const AGY_QUOTA_COMMAND_TEMPLATE = `Retrieve Agy Code Assist quota usage for the current authenticated account.
 
 Immediately call \`${AGY_QUOTA_TOOL_NAME}\` with no arguments and return its output verbatim.
+Do not call other tools.
+`;
+
+const AGY_QUOTA_SUMMARY_COMMAND = 'agyquotasummary';
+const AGY_QUOTA_SUMMARY_COMMAND_TEMPLATE = `Retrieve Agy Code Assist quota summary (weekly and 5-hour limits by model group) for the current authenticated account.
+
+Immediately call \`${AGY_QUOTA_SUMMARY_TOOL_NAME}\` with no arguments and return its output verbatim.
 Do not call other tools.
 `;
 let latestAgyAuthResolver: GetAuth | undefined;
@@ -333,6 +341,10 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
         description: 'Show Agy Code Assist quota usage',
         template: AGY_QUOTA_COMMAND_TEMPLATE
       };
+      config.command[AGY_QUOTA_SUMMARY_COMMAND] = {
+        description: 'Show Agy Code Assist quota summary with weekly and 5-hour limits',
+        template: AGY_QUOTA_SUMMARY_COMMAND_TEMPLATE
+      };
 
       // Dynamically registers the google-agy provider config to make it work seamlessly without manual user mapping.
       config.provider = config.provider || {};
@@ -349,6 +361,12 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
     },
     tool: {
       [AGY_QUOTA_TOOL_NAME]: createAgyQuotaTool({
+        client,
+        getAuthResolver: () => latestAgyAuthResolver,
+        getConfiguredProjectId: () => latestAgyConfiguredProjectId,
+        getUserAgentModel: () => latestAgyUserAgentModel
+      }),
+      [AGY_QUOTA_SUMMARY_TOOL_NAME]: createAgyQuotaSummaryTool({
         client,
         getAuthResolver: () => latestAgyAuthResolver,
         getConfiguredProjectId: () => latestAgyConfiguredProjectId,

--- a/src/plugin/project/index.ts
+++ b/src/plugin/project/index.ts
@@ -1,4 +1,4 @@
-export { retrieveUserQuota } from "../../sdk/fetch_quota";
+export { retrieveUserQuota, retrieveUserQuotaSummary } from "../../sdk/fetch_quota";
 export {
   ensureProjectContext,
   invalidateProjectContextCache,

--- a/src/plugin/project/types.ts
+++ b/src/plugin/project/types.ts
@@ -56,6 +56,30 @@ export interface RetrieveUserQuotaResponse {
   buckets?: RetrieveUserQuotaBucket[];
 }
 
+export interface QuotaSummaryBucket {
+  bucketId?: string;
+  displayName?: string;
+  description?: string;
+  window?: string;
+  remaining?: string;
+  remainingFraction?: number;
+  remainingAmount?: string;
+  disabled?: boolean;
+  resetTime?: string;
+}
+
+export interface QuotaSummaryGroup {
+  displayName?: string;
+  description?: string;
+  buckets?: QuotaSummaryBucket[];
+}
+
+export interface RetrieveUserQuotaSummaryResponse {
+  groups?: QuotaSummaryGroup[];
+  buckets?: QuotaSummaryBucket[];
+  description?: string;
+}
+
 /**
  * Thrown during Gemini enablement if the required Google Cloud project is missing.
  */

--- a/src/plugin/quota-summary.ts
+++ b/src/plugin/quota-summary.ts
@@ -97,7 +97,8 @@ function windowLabel(window: string | undefined): string {
 
 function formatSummaryBucket(bucket: QuotaSummaryBucket, indent: string): string[] {
   if (bucket.disabled) {
-    const desc = bucket.description?.trim() || "weekly limit exhausted";
+    const defaultDesc = `${windowLabel(bucket.window).toLowerCase()} exhausted`;
+    const desc = bucket.description?.trim() || defaultDesc;
     return [`${indent}Disabled: ${desc}`];
   }
 
@@ -126,7 +127,10 @@ function formatSummaryBucket(bucket: QuotaSummaryBucket, indent: string): string
 
   const resetLabel = formatRelativeResetTime(bucket.resetTime);
   if (resetLabel) {
-    lines.push(`${indent}${resetLabel.replace("resets in ", "Refreshes in ")}`);
+    const formattedReset = resetLabel.startsWith("resets in ")
+      ? resetLabel.replace("resets in ", "Refreshes in ")
+      : resetLabel.charAt(0).toUpperCase() + resetLabel.slice(1);
+    lines.push(`${indent}${formattedReset}`);
   }
 
   return lines;
@@ -183,7 +187,8 @@ function formatSummaryGroup(group: QuotaSummaryGroup): string[] {
         lines.push("");
       }
       for (const bucket of windowBuckets) {
-        const label = windowLabel(bucket.window);
+        const baseLabel = windowLabel(bucket.window);
+        const label = bucket.displayName ? `${baseLabel} (${bucket.displayName})` : baseLabel;
         lines.push(`  ${label}`);
         lines.push(...formatSummaryBucket(bucket, "    "));
         firstWindow = false;
@@ -204,7 +209,8 @@ function formatTopLevelBuckets(buckets: QuotaSummaryBucket[]): string[] {
       lines.push("");
     }
     for (const bucket of windowBuckets) {
-      const label = windowLabel(bucket.window);
+      const baseLabel = windowLabel(bucket.window);
+      const label = bucket.displayName ? `${baseLabel} (${bucket.displayName})` : baseLabel;
       lines.push(label);
       lines.push(...formatSummaryBucket(bucket, "  "));
       firstWindow = false;
@@ -231,7 +237,6 @@ function formatAgyQuotaSummaryOutput(
         continue;
       }
       if (i > 0) {
-        lines.push("");
         lines.push("");
       }
       lines.push(...formatSummaryGroup(group));

--- a/src/plugin/quota-summary.ts
+++ b/src/plugin/quota-summary.ts
@@ -1,0 +1,246 @@
+import { tool } from "@opencode-ai/plugin";
+import { accessTokenExpired, isOAuthAuth, parseRefreshParts } from "./auth";
+import { resolveCachedAuth } from "./cache";
+import { ensureProjectContext, retrieveUserQuotaSummary } from "./project";
+import type { QuotaSummaryBucket, QuotaSummaryGroup } from "./project/types";
+import { refreshAccessToken } from "./token";
+import type { GetAuth, PluginClient } from "./types";
+import { buildProgressBar, clamp, formatRemainingAmount, formatRelativeResetTime } from "./quota-utils";
+
+export const AGY_QUOTA_SUMMARY_TOOL_NAME = "agy_quota_summary";
+
+interface AgyQuotaSummaryToolDependencies {
+  client: PluginClient;
+  getAuthResolver: () => GetAuth | undefined;
+  getConfiguredProjectId: () => string | undefined;
+  getUserAgentModel: () => string | undefined;
+}
+
+export function createAgyQuotaSummaryTool({
+  client,
+  getAuthResolver,
+  getConfiguredProjectId,
+  getUserAgentModel,
+}: AgyQuotaSummaryToolDependencies) {
+  return tool({
+    description:
+      "Retrieve Agy Code Assist quota summary with weekly and 5-hour limits grouped by model family.",
+    args: {},
+    async execute() {
+      const getAuth = getAuthResolver();
+      if (!getAuth) {
+        return "Agy quota summary is unavailable before Google auth is initialized. Authenticate with the Google provider and retry.";
+      }
+
+      const auth = await getAuth();
+      if (!isOAuthAuth(auth)) {
+        return "Agy quota summary requires OAuth with Google. Run `opencode auth login` and choose `Google OAuth (Antigravity CLI)` or `Google OAuth (Gemini CLI)`.";
+      }
+
+      let authRecord = resolveCachedAuth(auth);
+      if (accessTokenExpired(authRecord)) {
+        const refreshed = await refreshAccessToken(authRecord, client);
+        if (!refreshed?.access) {
+          return "Agy quota summary lookup failed because the access token could not be refreshed. Re-authenticate and retry.";
+        }
+        authRecord = refreshed;
+      }
+
+      if (!authRecord.access) {
+        return "Agy quota summary lookup failed because no access token is available. Re-authenticate and retry.";
+      }
+
+      try {
+        const projectContext = await ensureProjectContext(
+          authRecord,
+          client,
+          getConfiguredProjectId(),
+          getUserAgentModel(),
+        );
+        if (!projectContext.effectiveProjectId) {
+          return "Agy quota summary lookup failed because no Google Cloud project could be resolved.";
+        }
+
+        const summary = await retrieveUserQuotaSummary(
+          authRecord.access,
+          projectContext.effectiveProjectId,
+          getUserAgentModel(),
+        );
+        if (!summary) {
+          return `No Agy quota summary available for project \`${projectContext.effectiveProjectId}\`.`;
+        }
+
+        return formatAgyQuotaSummaryOutput(
+          projectContext.effectiveProjectId,
+          summary,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "unknown error";
+        return `Agy quota summary lookup failed: ${message}`;
+      }
+    },
+  });
+}
+
+const BAR_WIDTH = 50;
+
+function windowLabel(window: string | undefined): string {
+  switch (window?.toUpperCase()) {
+    case "WEEKLY":
+      return "Weekly Limit";
+    case "FIVE_HOUR":
+      return "Five Hour Limit";
+    default:
+      return "Other Limit";
+  }
+}
+
+function formatSummaryBucket(bucket: QuotaSummaryBucket, indent: string): string[] {
+  if (bucket.disabled) {
+    const desc = bucket.description?.trim() || "weekly limit exhausted";
+    return [`${indent}Disabled: ${desc}`];
+  }
+
+  const lines: string[] = [];
+  const fraction = bucket.remainingFraction;
+  const hasFraction = typeof fraction === "number" && Number.isFinite(fraction);
+
+  if (hasFraction) {
+    const clamped = clamp(fraction, 0, 1);
+    const percent = (clamped * 100).toFixed(2);
+    const bar = buildProgressBar(clamped, BAR_WIDTH);
+    lines.push(`${indent}[${bar}] ${percent}%`);
+
+    const remaining = formatRemainingAmount(bucket.remainingAmount);
+    if (remaining) {
+      const pctWhole = (clamped * 100).toFixed(0);
+      lines.push(`${indent}${pctWhole}% remaining \u00b7 ${remaining} left`);
+    } else {
+      const pctWhole = (clamped * 100).toFixed(0);
+      lines.push(`${indent}${pctWhole}% remaining`);
+    }
+  } else {
+    const remaining = formatRemainingAmount(bucket.remainingAmount);
+    lines.push(remaining ? `${indent}${remaining} remaining` : `${indent}unknown remaining`);
+  }
+
+  const resetLabel = formatRelativeResetTime(bucket.resetTime);
+  if (resetLabel) {
+    lines.push(`${indent}${resetLabel.replace("resets in ", "Refreshes in ")}`);
+  }
+
+  return lines;
+}
+
+function groupBucketsByWindow(buckets: QuotaSummaryBucket[]): Map<string, QuotaSummaryBucket[]> {
+  const groups = new Map<string, QuotaSummaryBucket[]>();
+  const order = ["WEEKLY", "FIVE_HOUR"];
+
+  for (const bucket of buckets) {
+    const key = bucket.window?.toUpperCase() || "UNKNOWN";
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(bucket);
+    } else {
+      groups.set(key, [bucket]);
+    }
+  }
+
+  const sorted = new Map<string, QuotaSummaryBucket[]>();
+  for (const key of order) {
+    const group = groups.get(key);
+    if (group) {
+      sorted.set(key, group);
+    }
+  }
+  for (const [key, group] of groups) {
+    if (!sorted.has(key)) {
+      sorted.set(key, group);
+    }
+  }
+
+  return sorted;
+}
+
+function formatSummaryGroup(group: QuotaSummaryGroup): string[] {
+  const lines: string[] = [];
+  const name = group.displayName?.trim();
+  if (name) {
+    lines.push(name);
+  }
+
+  const desc = group.description?.trim();
+  if (desc) {
+    lines.push(`  Models within this group: ${desc}`);
+  }
+
+  const buckets = group.buckets;
+  if (buckets?.length) {
+    const windowGroups = groupBucketsByWindow(buckets);
+    let firstWindow = true;
+    for (const [, windowBuckets] of windowGroups) {
+      if (!firstWindow) {
+        lines.push("");
+      }
+      for (const bucket of windowBuckets) {
+        const label = windowLabel(bucket.window);
+        lines.push(`  ${label}`);
+        lines.push(...formatSummaryBucket(bucket, "    "));
+        firstWindow = false;
+      }
+    }
+  }
+
+  return lines;
+}
+
+function formatTopLevelBuckets(buckets: QuotaSummaryBucket[]): string[] {
+  const lines: string[] = [];
+  const windowGroups = groupBucketsByWindow(buckets);
+
+  let firstWindow = true;
+  for (const [, windowBuckets] of windowGroups) {
+    if (!firstWindow) {
+      lines.push("");
+    }
+    for (const bucket of windowBuckets) {
+      const label = windowLabel(bucket.window);
+      lines.push(label);
+      lines.push(...formatSummaryBucket(bucket, "  "));
+      firstWindow = false;
+    }
+  }
+
+  return lines;
+}
+
+function formatAgyQuotaSummaryOutput(
+  projectId: string,
+  summary: { groups?: QuotaSummaryGroup[]; buckets?: QuotaSummaryBucket[]; description?: string },
+): string {
+  const lines = [
+    `Agy quota summary for project \`${projectId}\``,
+    "",
+  ];
+
+  const groups = summary.groups;
+  if (groups?.length) {
+    for (let i = 0; i < groups.length; i++) {
+      const group = groups[i];
+      if (!group) {
+        continue;
+      }
+      if (i > 0) {
+        lines.push("");
+        lines.push("");
+      }
+      lines.push(...formatSummaryGroup(group));
+    }
+  } else if (summary.buckets?.length) {
+    lines.push(...formatTopLevelBuckets(summary.buckets));
+  } else {
+    lines.push("No quota information available.");
+  }
+
+  return lines.join("\n");
+}

--- a/src/plugin/quota-utils.ts
+++ b/src/plugin/quota-utils.ts
@@ -1,4 +1,7 @@
 export function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) {
+    return min;
+  }
   if (value < min) {
     return min;
   }
@@ -28,7 +31,7 @@ export function formatRemainingAmount(value: string | undefined): string | undef
   if (!value) {
     return undefined;
   }
-  const parsed = Number.parseInt(value, 10);
+  const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
     return value;
   }

--- a/src/plugin/quota-utils.ts
+++ b/src/plugin/quota-utils.ts
@@ -1,0 +1,64 @@
+export function clamp(value: number, min: number, max: number): number {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+export function pad(value: string, width: number): string {
+  if (value.length >= width) {
+    return value;
+  }
+  return value.padEnd(width, " ");
+}
+
+export function buildProgressBar(fraction: number, width = 20): string {
+  const clamped = clamp(fraction, 0, 1);
+  const filled = clamped >= 1
+    ? width
+    : Math.max(0, Math.min(width, Math.max(clamped > 0 ? 1 : 0, Math.floor(clamped * width))));
+  const empty = width - filled;
+  return `${"▓".repeat(filled)}${"░".repeat(empty)}`;
+}
+
+export function formatRemainingAmount(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  return parsed.toLocaleString("en-US");
+}
+
+export function formatRelativeResetTime(resetTime: string | undefined): string | undefined {
+  if (!resetTime) {
+    return undefined;
+  }
+
+  const resetAt = new Date(resetTime).getTime();
+  if (Number.isNaN(resetAt)) {
+    return undefined;
+  }
+
+  const diffMs = resetAt - Date.now();
+  if (diffMs <= 0) {
+    return "reset pending";
+  }
+
+  const totalMinutes = Math.ceil(diffMs / (1000 * 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) {
+    return `resets in ${hours}h ${minutes}m`;
+  }
+  if (hours > 0) {
+    return `resets in ${hours}h`;
+  }
+  return `resets in ${minutes}m`;
+}

--- a/src/plugin/quota.ts
+++ b/src/plugin/quota.ts
@@ -5,6 +5,7 @@ import { ensureProjectContext, retrieveUserQuota } from "./project";
 import type { RetrieveUserQuotaBucket } from "./project/types";
 import { refreshAccessToken } from "./token";
 import type { GetAuth, PluginClient } from "./types";
+import { buildProgressBar, clamp, formatRemainingAmount, formatRelativeResetTime, pad } from "./quota-utils";
 
 export const AGY_QUOTA_TOOL_NAME = "agy_quota";
 
@@ -169,71 +170,6 @@ function formatUsageRemaining(bucket: RetrieveUserQuotaBucket): string {
   }
 
   return "unknown";
-}
-
-function formatRemainingAmount(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed)) {
-    return value;
-  }
-  return parsed.toLocaleString("en-US");
-}
-
-function formatRelativeResetTime(resetTime: string | undefined): string | undefined {
-  if (!resetTime) {
-    return undefined;
-  }
-
-  const resetAt = new Date(resetTime).getTime();
-  if (Number.isNaN(resetAt)) {
-    return undefined;
-  }
-
-  const diffMs = resetAt - Date.now();
-  if (diffMs <= 0) {
-    return "reset pending";
-  }
-
-  const totalMinutes = Math.ceil(diffMs / (1000 * 60));
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-
-  if (hours > 0 && minutes > 0) {
-    return `resets in ${hours}h ${minutes}m`;
-  }
-  if (hours > 0) {
-    return `resets in ${hours}h`;
-  }
-  return `resets in ${minutes}m`;
-}
-
-function buildProgressBar(fraction: number, width = 20): string {
-  const clamped = clamp(fraction, 0, 1);
-  const filled = clamped >= 1
-    ? width
-    : Math.max(0, Math.min(width, Math.max(clamped > 0 ? 1 : 0, Math.floor(clamped * width))));
-  const empty = width - filled;
-  return `${"▓".repeat(filled)}${"░".repeat(empty)}`;
-}
-
-function pad(value: string, width: number): string {
-  if (value.length >= width) {
-    return value;
-  }
-  return value.padEnd(width, " ");
-}
-
-function clamp(value: number, min: number, max: number): number {
-  if (value < min) {
-    return min;
-  }
-  if (value > max) {
-    return max;
-  }
-  return value;
 }
 
 function normalizeTokenType(bucket: RetrieveUserQuotaBucket): string {

--- a/src/sdk/fetch_quota.ts
+++ b/src/sdk/fetch_quota.ts
@@ -2,7 +2,7 @@ import { AGY_CODE_ASSIST_ENDPOINT } from '../constants';
 import { agyFetch } from '../fetch';
 import { createAgyActivityRequestId } from './activity-request-id';
 import { buildAgyCliUserAgent } from './user-agent';
-import type { RetrieveUserQuotaResponse } from '../plugin/project/types';
+import type { RetrieveUserQuotaResponse, RetrieveUserQuotaSummaryResponse } from '../plugin/project/types';
 
 /**
  * Fetches the Code Assist quota bucket information, which contains the model IDs visible to the current account/project.
@@ -26,6 +26,33 @@ export async function retrieveUserQuota(
       return null;
     }
     return (await response.json()) as RetrieveUserQuotaResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetches the Code Assist quota summary, grouped by model family with window-based buckets.
+ */
+export async function retrieveUserQuotaSummary(
+  accessToken: string,
+  projectId: string,
+  userAgentModel?: string
+): Promise<RetrieveUserQuotaSummaryResponse | null> {
+  const url = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal:retrieveUserQuotaSummary`;
+  const headers = buildCodeAssistHeaders(accessToken, userAgentModel);
+
+  try {
+    const response = await agyFetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ project: projectId })
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as RetrieveUserQuotaSummaryResponse;
   } catch {
     return null;
   }


### PR DESCRIPTION
Add a new `/agyquotasummary` slash command and `agy_quota_summary` tool that calls the `v1internal:retrieveUserQuotaSummary` endpoint to show quota grouped by model family with weekly and 5-hour window buckets.

- Extract shared helpers to quota-utils.ts (buildProgressBar, clamp, pad, formatRemainingAmount, formatRelativeResetTime)
- Refactor quota.ts to import from quota-utils.ts
- Add QuotaSummaryBucket, QuotaSummaryGroup, and RetrieveUserQuotaSummaryResponse types
- Add retrieveUserQuotaSummary() SDK function
- Create quota-summary.ts with grouped display (50-char bars, Weekly/Five Hour limit sections, disabled bucket support)
