### PR TITLE
fix: local plugin crash + add persistent state tracking, SHA-256 hashing, and cooldown disk persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ Additionally, you can quickly check your quota using the `/agyquota` slash comma
 
 This calls the injected `agy_quota` tool to give you a real-time table of your current usage, tokens remaining, and reset times.
 
+### Disk Persistence
+
+The plugin persists turn-state and retry-cooldown data to disk so that it survives OpenCode restarts. Files are stored under `~/.config/opencode/` (or `%APPDATA%\opencode\` on Windows):
+
+- `antigravity-turn-states.json` - tracks thinking/reasoning state across request turns, with a 24-hour TTL and 5-second throttled writes using atomic tmp+rename.
+- Retry cooldowns are persisted via `CooldownStore` with the same atomic-write pattern.
+
+Both stores initialize lazily at runtime - no filesystem reads occur at import time.
+
+#### `diskEnabled` Parameter
+
+`TurnStateTracker` accepts a `diskEnabled` constructor parameter (defaults to `true`):
+
+```ts
+import { TurnStateTracker } from "@anthonyhaussman/opencode-agy-auth/sdk/request/turn-state-tracker";
+
+// Disk persistence enabled (default)
+const tracker = new TurnStateTracker(true);
+
+// Memory-only mode - no filesystem reads or writes
+const tracker = new TurnStateTracker(false);
+```
+
+When `diskEnabled` is `false`, the tracker operates entirely in memory. All state is lost when the process exits. This is useful in restricted environments (containers, read-only filesystems) where disk access is unavailable or undesirable.
+
+If disk initialization fails at runtime (permission error, corrupt file, etc.), the plugin automatically falls back to memory-only mode and logs a warning. No configuration is needed for normal use - disk persistence works out of the box.
+
 ## Local Testing
 
 To test and develop the plugin locally with OpenCode before publishing:

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,12 @@
 import { AgyCLIOAuthPlugin, GoogleOAuthPlugin } from "./src/plugin";
+import { shutdownRetryCooldowns } from "./src/sdk/retry";
+import { shutdownTurnStateTracker } from "./src/sdk/request/turn-state-tracker";
 
 export { AgyCLIOAuthPlugin, GoogleOAuthPlugin };
+
+export function shutdownAgyPlugin(): void {
+  shutdownRetryCooldowns();
+  shutdownTurnStateTracker();
+}
+
 export default AgyCLIOAuthPlugin;

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,8 @@
 import { AgyCLIOAuthPlugin, GoogleOAuthPlugin } from "./src/plugin";
-import { shutdownRetryCooldowns } from "./src/sdk/retry";
-import { shutdownTurnStateTracker } from "./src/sdk/request/turn-state-tracker";
 
 export { AgyCLIOAuthPlugin, GoogleOAuthPlugin };
 
-export function shutdownAgyPlugin(): void {
-  shutdownRetryCooldowns();
-  shutdownTurnStateTracker();
-}
-
-export default AgyCLIOAuthPlugin;
+export default {
+  id: "@anthonyhaussman/opencode-agy-auth",
+  server: AgyCLIOAuthPlugin,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-alpha.4",
+  "version": "1.0.11-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.11-alpha.4",
+      "version": "1.0.11-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-beta.0",
+  "version": "1.0.11-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.11-beta.0",
+      "version": "1.0.11-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-alpha.4",
+  "version": "1.0.11-alpha.5",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11-beta.0",
+  "version": "1.0.11-alpha.4",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,7 @@ import { agyFetch } from './fetch';
 import { createOAuthAuthorizeMethod } from './plugin/oauth-authorize';
 import { accessTokenExpired, isOAuthAuth, parseRefreshParts } from './plugin/auth';
 import { resolveCachedAuth, initDiskSignatureCache } from './plugin/cache';
+import { initTurnStateTracker, shutdownTurnStateTracker } from './sdk/request/turn-state-tracker';
 import { ensureProjectContext, retrieveUserQuota, retrieveUserQuotaSummary } from './plugin/project';
 import { createAgyQuotaTool, AGY_QUOTA_TOOL_NAME } from './plugin/quota';
 import { createAgyQuotaSummaryTool, AGY_QUOTA_SUMMARY_TOOL_NAME } from './plugin/quota-summary';
@@ -321,6 +322,8 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
     disk_ttl_seconds: 86400,
     write_interval_seconds: 30
   });
+
+  initTurnStateTracker();
 
   const resolveLatestConfiguredProjectId = async (provider?: Provider): Promise<string | undefined> => {
     const configProjectId = (await resolveConfiguredProjectIdFromClient(client)) ?? latestAgyConfiguredProjectId;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,7 +4,8 @@ import { agyFetch } from './fetch';
 import { createOAuthAuthorizeMethod } from './plugin/oauth-authorize';
 import { accessTokenExpired, isOAuthAuth, parseRefreshParts } from './plugin/auth';
 import { resolveCachedAuth, initDiskSignatureCache } from './plugin/cache';
-import { initTurnStateTracker, shutdownTurnStateTracker } from './sdk/request/turn-state-tracker';
+import { initTurnStateTracker } from './sdk/request/turn-state-tracker';
+import { initCooldownPersistence } from './sdk/retry';
 import { ensureProjectContext, retrieveUserQuota, retrieveUserQuotaSummary } from './plugin/project';
 import { createAgyQuotaTool, AGY_QUOTA_TOOL_NAME } from './plugin/quota';
 import { createAgyQuotaSummaryTool, AGY_QUOTA_SUMMARY_TOOL_NAME } from './plugin/quota-summary';
@@ -316,14 +317,28 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
     return STATIC_MODELS;
   };
 
-  initDiskSignatureCache({
-    enabled: true,
-    memory_ttl_seconds: 3600,
-    disk_ttl_seconds: 86400,
-    write_interval_seconds: 30
-  });
+  try {
+    initDiskSignatureCache({
+      enabled: true,
+      memory_ttl_seconds: 3600,
+      disk_ttl_seconds: 86400,
+      write_interval_seconds: 30
+    });
+  } catch (e) {
+    console.warn(`[Agy Auth] initDiskSignatureCache failed, running without signature disk cache: ${e instanceof Error ? e.message : e}`);
+  }
 
-  initTurnStateTracker();
+  try {
+    initTurnStateTracker();
+  } catch (e) {
+    console.warn(`[Agy Auth] initTurnStateTracker failed, running without turn-state tracking: ${e instanceof Error ? e.message : e}`);
+  }
+
+  try {
+    initCooldownPersistence();
+  } catch (e) {
+    console.warn(`[Agy Auth] initCooldownPersistence failed, running without cooldown disk persistence: ${e instanceof Error ? e.message : e}`);
+  }
 
   const resolveLatestConfiguredProjectId = async (provider?: Provider): Promise<string | undefined> => {
     const configProjectId = (await resolveConfiguredProjectIdFromClient(client)) ?? latestAgyConfiguredProjectId;

--- a/src/sdk/request/index.ts
+++ b/src/sdk/request/index.ts
@@ -8,3 +8,5 @@ export { prepareAgyRequest } from "./prepare";
 export type { ThinkingConfigDefaults } from "./prepare";
 export { transformAgyResponse } from "./response";
 export { isGenerativeLanguageRequest, parseGenerativeLanguageRequest } from "./shared";
+export { initTurnStateTracker, getTurnStateTracker, shutdownTurnStateTracker, TurnStateTracker } from "./turn-state-tracker";
+export type { TurnState } from "./turn-state-tracker";

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -171,12 +171,8 @@ function transformRequestBody(
         const tracker = getTurnStateTracker();
         let needsRecovery = false;
         if (sessionId && tracker) {
-          const existing = tracker.getState(sessionId);
-          if (existing) {
-            needsRecovery = existing.inToolLoop && !existing.turnHasThinking;
-          } else {
-            needsRecovery = tracker.recoverFromContents(sessionId, contents).inToolLoop && !tracker.getState(sessionId)?.turnHasThinking;
-          }
+          const state = tracker.getState(sessionId) ?? tracker.recoverFromContents(sessionId, contents);
+          needsRecovery = state.inToolLoop && !state.turnHasThinking;
         }
         if (needsRecovery) {
           contents = closeToolLoopForThinking(contents);
@@ -216,12 +212,8 @@ function transformRequestBody(
       const tracker = getTurnStateTracker();
       let needsRecovery = false;
       if (sessionId && tracker) {
-        const existing = tracker.getState(sessionId);
-        if (existing) {
-          needsRecovery = existing.inToolLoop && !existing.turnHasThinking;
-        } else {
-          needsRecovery = tracker.recoverFromContents(sessionId, contents).inToolLoop && !tracker.getState(sessionId)?.turnHasThinking;
-        }
+        const state = tracker.getState(sessionId) ?? tracker.recoverFromContents(sessionId, contents);
+        needsRecovery = state.inToolLoop && !state.turnHasThinking;
       }
       if (needsRecovery) {
         contents = closeToolLoopForThinking(contents);

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -8,11 +8,8 @@ import { normalizeRequestPayloadIdentifiers, normalizeWrappedIdentifiers } from 
 import { addThoughtSignaturesToFunctionCalls, transformOpenAIToolCalls } from "./openai";
 import { isGenerativeLanguageRequest, parseGenerativeLanguageRequest } from "./shared";
 import { getLatestSignature } from "../../plugin/cache";
-import {
-  analyzeConversationState,
-  needsThinkingRecovery,
-  closeToolLoopForThinking,
-} from "./thinking";
+import { closeToolLoopForThinking } from "./thinking";
+import { getTurnStateTracker } from "./turn-state-tracker";
 
 const STREAM_ACTION = "streamGenerateContent";
 
@@ -171,8 +168,17 @@ function transformRequestBody(
         injectMissingToolCallIds(contents);
         fixOrphanedFunctionResponses(contents);
 
-        const state = analyzeConversationState(contents);
-        if (needsThinkingRecovery(state)) {
+        const tracker = getTurnStateTracker();
+        let needsRecovery = false;
+        if (sessionId && tracker) {
+          const existing = tracker.getState(sessionId);
+          if (existing) {
+            needsRecovery = existing.inToolLoop && !existing.turnHasThinking;
+          } else {
+            needsRecovery = tracker.recoverFromContents(sessionId, contents).inToolLoop && !tracker.getState(sessionId)?.turnHasThinking;
+          }
+        }
+        if (needsRecovery) {
           contents = closeToolLoopForThinking(contents);
         }
 
@@ -207,8 +213,17 @@ function transformRequestBody(
       injectMissingToolCallIds(contents);
       fixOrphanedFunctionResponses(contents);
 
-      const state = analyzeConversationState(contents);
-      if (needsThinkingRecovery(state)) {
+      const tracker = getTurnStateTracker();
+      let needsRecovery = false;
+      if (sessionId && tracker) {
+        const existing = tracker.getState(sessionId);
+        if (existing) {
+          needsRecovery = existing.inToolLoop && !existing.turnHasThinking;
+        } else {
+          needsRecovery = tracker.recoverFromContents(sessionId, contents).inToolLoop && !tracker.getState(sessionId)?.turnHasThinking;
+        }
+      }
+      if (needsRecovery) {
         contents = closeToolLoopForThinking(contents);
       }
 

--- a/src/sdk/request/response.ts
+++ b/src/sdk/request/response.ts
@@ -9,6 +9,7 @@ import {
 import { injectResponseIdFromTrace } from "./shared";
 import { cacheSignature } from "../../plugin/cache";
 import { createStreamingTransformer, defaultSignatureStore } from "./thinking";
+import { getTurnStateTracker, type TurnState } from "./turn-state-tracker";
 import type { ChatLogger } from "../chat-logger";
 
 /**
@@ -129,6 +130,17 @@ function transformStreamingPayloadStream(
   const callbacks = {
     onCacheSignature: (sessionKey: string, text: string, signature: string) => {
       cacheSignature(sessionKey, text, signature);
+    },
+    onTurnStateUpdate: (sessionKey: string, state: { turnHasThinking: boolean; lastModelHasToolCalls: boolean }) => {
+      const tracker = getTurnStateTracker();
+      if (tracker) {
+        tracker.updateAfterResponse(sessionKey, {
+          inToolLoop: state.lastModelHasToolCalls,
+          turnHasThinking: state.turnHasThinking,
+          lastModelHasThinking: state.turnHasThinking,
+          lastModelHasToolCalls: state.lastModelHasToolCalls,
+        });
+      }
     },
     transformThinkingParts: (response: unknown) => {
       if (response && typeof response === "object") {

--- a/src/sdk/request/thinking.ts
+++ b/src/sdk/request/thinking.ts
@@ -38,12 +38,10 @@ export interface SignatureStore {
  * Custom callback functions for the streaming phase
  */
 export interface StreamingCallbacks {
-  /** Triggered when the latest thought chain and signature are cached */
   onCacheSignature?: (sessionKey: string, text: string, signature: string) => void;
-  /** Triggered when debugging instructions (e.g., quota overrun warnings) need injection into the stream */
   onInjectDebug?: (response: unknown, debugText: string) => unknown;
-  /** Method to transform custom thought chain parts */
   transformThinkingParts?: (parts: unknown) => unknown;
+  onTurnStateUpdate?: (sessionKey: string, state: { turnHasThinking: boolean; lastModelHasToolCalls: boolean }) => void;
 }
 
 /**
@@ -133,15 +131,14 @@ export const defaultSignatureStore = createSignatureStore();
 // Hashing Helper
 // ============================================================================
 
+const THINKING_HASH_HEX_LEN = 16;
+
 /**
- * Generates a fast string hash (DJB2 algorithm) to deduplicate already output thought chain blocks
+ * Generates a SHA-256 hash of the thought chain content, truncated to 16 hex characters.
+ * Consistent with the signature cache hash width in cache.ts.
  */
 function hashString(str: string): string {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash) + str.charCodeAt(i);
-  }
-  return (hash >>> 0).toString(16);
+  return createHash("sha256").update(str, "utf8").digest("hex").slice(0, THINKING_HASH_HEX_LEN);
 }
 
 // ============================================================================
@@ -674,6 +671,8 @@ export function createStreamingTransformer(
   const sentThinkingBuffer = createThoughtBuffer();
   const debugState = { injected: false };
   let hasSeenUsageMetadata = false;
+  let streamHasThinking = false;
+  let streamHasToolCalls = false;
 
   const displayedThinkingHashes = options.displayedThinkingHashes ?? new Set<string>();
   const mergedOptions = { ...options, displayedThinkingHashes };
@@ -689,6 +688,12 @@ export function createStreamingTransformer(
         if (!event.trim()) continue; // Skip empty events if any
         if (event.includes("usageMetadata")) {
           hasSeenUsageMetadata = true;
+        }
+        if (!streamHasThinking) {
+          streamHasThinking = event.includes('"thought":true') || event.includes('"type":"thinking"');
+        }
+        if (!streamHasToolCalls) {
+          streamHasToolCalls = event.includes('"functionCall"');
         }
 
         const transformedEvent = transformSseEvent(
@@ -709,6 +714,12 @@ export function createStreamingTransformer(
       if (buffer.trim()) {
         if (buffer.includes("usageMetadata")) {
           hasSeenUsageMetadata = true;
+        }
+        if (!streamHasThinking) {
+          streamHasThinking = buffer.includes('"thought":true') || buffer.includes('"type":"thinking"');
+        }
+        if (!streamHasToolCalls) {
+          streamHasToolCalls = buffer.includes('"functionCall"');
         }
         const transformedEvent = transformSseEvent(
           buffer,
@@ -737,6 +748,13 @@ export function createStreamingTransformer(
           },
         };
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(syntheticUsage)}\n\n`));
+      }
+
+      if (callbacks.onTurnStateUpdate && options.signatureSessionKey) {
+        callbacks.onTurnStateUpdate(options.signatureSessionKey, {
+          turnHasThinking: streamHasThinking,
+          lastModelHasToolCalls: streamHasToolCalls,
+        });
       }
     },
   });

--- a/src/sdk/request/turn-state-tracker.ts
+++ b/src/sdk/request/turn-state-tracker.ts
@@ -104,9 +104,13 @@ export class TurnStateTracker {
   private dirty = false;
   private lastWriteTime = 0;
   private writeTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly diskEnabled: boolean;
 
-  constructor() {
-    this.entries = loadTurnStatesFromDisk();
+  constructor(diskEnabled = true) {
+    this.diskEnabled = diskEnabled;
+    if (diskEnabled) {
+      this.entries = loadTurnStatesFromDisk();
+    }
   }
 
   getState(sessionId: string): TurnState | undefined {
@@ -149,13 +153,14 @@ export class TurnStateTracker {
 
   shutdown(): void {
     this.clearWriteTimer();
-    if (this.dirty) {
+    if (this.dirty && this.diskEnabled) {
       saveTurnStatesToDisk(this.entries);
       this.dirty = false;
     }
   }
 
   private scheduleThrottledWrite(): void {
+    if (!this.diskEnabled) return;
     if (this.writeTimer) {
       return;
     }
@@ -189,7 +194,11 @@ let trackerInstance: TurnStateTracker | null = null;
 
 export function initTurnStateTracker(): TurnStateTracker {
   if (!trackerInstance) {
-    trackerInstance = new TurnStateTracker();
+    try {
+      trackerInstance = new TurnStateTracker(true);
+    } catch {
+      trackerInstance = new TurnStateTracker(false);
+    }
   }
   return trackerInstance;
 }

--- a/src/sdk/request/turn-state-tracker.ts
+++ b/src/sdk/request/turn-state-tracker.ts
@@ -196,6 +196,11 @@ export function initTurnStateTracker(): TurnStateTracker {
   if (!trackerInstance) {
     try {
       trackerInstance = new TurnStateTracker(true);
+      if (typeof process !== "undefined") {
+        process.on("exit", () => {
+          trackerInstance?.shutdown();
+        });
+      }
     } catch {
       trackerInstance = new TurnStateTracker(false);
     }

--- a/src/sdk/request/turn-state-tracker.ts
+++ b/src/sdk/request/turn-state-tracker.ts
@@ -1,0 +1,206 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { analyzeConversationState, type ConversationState } from "./thinking";
+
+export type TurnState = Pick<ConversationState, "inToolLoop" | "turnHasThinking" | "lastModelHasThinking" | "lastModelHasToolCalls">;
+
+interface TurnStateRecord {
+  state: TurnState;
+  updatedAt: number;
+}
+
+interface TurnStateData {
+  version: "1.0";
+  entries: Record<string, TurnStateRecord>;
+  updatedAt: number;
+}
+
+const WRITE_THROTTLE_MS = 5000;
+
+function getConfigDir(): string {
+  const platform = process.platform;
+  if (platform === "win32") {
+    return join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "opencode");
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdgConfig, "opencode");
+}
+
+function getTurnStateFilePath(): string {
+  return join(getConfigDir(), "antigravity-turn-states.json");
+}
+
+function loadTurnStatesFromDisk(): Map<string, TurnStateRecord> {
+  const result = new Map<string, TurnStateRecord>();
+  try {
+    const filePath = getTurnStateFilePath();
+    if (!existsSync(filePath)) {
+      return result;
+    }
+
+    const content = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content) as TurnStateData;
+    if (data.version !== "1.0") {
+      return result;
+    }
+
+    const now = Date.now();
+    const maxAge = 24 * 60 * 60 * 1000;
+    for (const [key, record] of Object.entries(data.entries)) {
+      if (record.state && typeof record.state === "object" && now - record.updatedAt < maxAge) {
+        result.set(key, record);
+      }
+    }
+  } catch {
+  }
+  return result;
+}
+
+function saveTurnStatesToDisk(entries: Map<string, TurnStateRecord>): boolean {
+  try {
+    const filePath = getTurnStateFilePath();
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const now = Date.now();
+    const maxAge = 24 * 60 * 60 * 1000;
+    const serializable: Record<string, TurnStateRecord> = {};
+    for (const [key, record] of entries.entries()) {
+      if (now - record.updatedAt < maxAge) {
+        serializable[key] = record;
+      }
+    }
+
+    const data: TurnStateData = {
+      version: "1.0",
+      entries: serializable,
+      updatedAt: now,
+    };
+
+    const tmpPath = join(tmpdir(), `antigravity-turn-states-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+    writeFileSync(tmpPath, JSON.stringify(data), "utf-8");
+
+    try {
+      renameSync(tmpPath, filePath);
+    } catch {
+      writeFileSync(filePath, readFileSync(tmpPath));
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class TurnStateTracker {
+  private entries = new Map<string, TurnStateRecord>();
+  private dirty = false;
+  private lastWriteTime = 0;
+  private writeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    this.entries = loadTurnStatesFromDisk();
+  }
+
+  getState(sessionId: string): TurnState | undefined {
+    const record = this.entries.get(sessionId);
+    if (!record) return undefined;
+    return record.state;
+  }
+
+  needsThinkingRecovery(sessionId: string): boolean {
+    const state = this.entries.get(sessionId);
+    if (!state) return false;
+    return state.state.inToolLoop && !state.state.turnHasThinking;
+  }
+
+  updateAfterResponse(sessionId: string, newState: TurnState): void {
+    this.entries.set(sessionId, { state: newState, updatedAt: Date.now() });
+    this.dirty = true;
+    this.scheduleThrottledWrite();
+  }
+
+  recoverFromContents(sessionId: string, contents: any[]): TurnState {
+    const fullState = analyzeConversationState(contents);
+    const turnState: TurnState = {
+      inToolLoop: fullState.inToolLoop,
+      turnHasThinking: fullState.turnHasThinking,
+      lastModelHasThinking: fullState.lastModelHasThinking,
+      lastModelHasToolCalls: fullState.lastModelHasToolCalls,
+    };
+    this.entries.set(sessionId, { state: turnState, updatedAt: Date.now() });
+    this.dirty = true;
+    this.scheduleThrottledWrite();
+    return turnState;
+  }
+
+  clear(sessionId: string): void {
+    this.entries.delete(sessionId);
+    this.dirty = true;
+    this.scheduleThrottledWrite();
+  }
+
+  shutdown(): void {
+    this.clearWriteTimer();
+    if (this.dirty) {
+      saveTurnStatesToDisk(this.entries);
+      this.dirty = false;
+    }
+  }
+
+  private scheduleThrottledWrite(): void {
+    if (this.writeTimer) {
+      return;
+    }
+
+    const elapsed = Date.now() - this.lastWriteTime;
+    const remaining = Math.max(0, WRITE_THROTTLE_MS - elapsed);
+
+    this.writeTimer = setTimeout(() => {
+      this.writeTimer = null;
+      this.lastWriteTime = Date.now();
+      if (this.dirty) {
+        this.dirty = false;
+        saveTurnStatesToDisk(this.entries);
+      }
+    }, remaining);
+
+    if (this.writeTimer && typeof this.writeTimer === "object" && "unref" in this.writeTimer) {
+      this.writeTimer.unref();
+    }
+  }
+
+  private clearWriteTimer(): void {
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+  }
+}
+
+let trackerInstance: TurnStateTracker | null = null;
+
+export function initTurnStateTracker(): TurnStateTracker {
+  if (!trackerInstance) {
+    trackerInstance = new TurnStateTracker();
+  }
+  return trackerInstance;
+}
+
+export function getTurnStateTracker(): TurnStateTracker | null {
+  return trackerInstance;
+}
+
+export function shutdownTurnStateTracker(): void {
+  if (trackerInstance) {
+    trackerInstance.shutdown();
+    trackerInstance = null;
+  }
+}

--- a/src/sdk/retry/cooldown-store.ts
+++ b/src/sdk/retry/cooldown-store.ts
@@ -1,0 +1,152 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir, tmpdir } from "node:os";
+
+interface CooldownData {
+  version: "1.0";
+  entries: Record<string, number>;
+  updatedAt: number;
+}
+
+const WRITE_THROTTLE_MS = 5000;
+
+function getConfigDir(): string {
+  const platform = process.platform;
+  if (platform === "win32") {
+    return join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "opencode");
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdgConfig, "opencode");
+}
+
+function getCooldownFilePath(): string {
+  return join(getConfigDir(), "antigravity-retry-cooldowns.json");
+}
+
+export function loadCooldowns(): Map<string, number> {
+  const result = new Map<string, number>();
+  try {
+    const filePath = getCooldownFilePath();
+    if (!existsSync(filePath)) {
+      return result;
+    }
+
+    const content = readFileSync(filePath, "utf-8");
+    const data = JSON.parse(content) as CooldownData;
+    if (data.version !== "1.0") {
+      return result;
+    }
+
+    const now = Date.now();
+    for (const [key, expiresAt] of Object.entries(data.entries)) {
+      if (typeof expiresAt === "number" && expiresAt > now) {
+        result.set(key, expiresAt);
+      }
+    }
+  } catch {
+    // Fault tolerance: start fresh on disk load failure
+  }
+  return result;
+}
+
+export function saveCooldowns(entries: Map<string, number>): boolean {
+  try {
+    const filePath = getCooldownFilePath();
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const now = Date.now();
+    const serializable: Record<string, number> = {};
+    for (const [key, expiresAt] of entries.entries()) {
+      if (expiresAt > now) {
+        serializable[key] = expiresAt;
+      }
+    }
+
+    const data: CooldownData = {
+      version: "1.0",
+      entries: serializable,
+      updatedAt: now,
+    };
+
+    const tmpPath = join(tmpdir(), `antigravity-cooldowns-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`);
+    writeFileSync(tmpPath, JSON.stringify(data), "utf-8");
+
+    try {
+      renameSync(tmpPath, filePath);
+    } catch {
+      writeFileSync(filePath, readFileSync(tmpPath));
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // Ignore temp file deletion failure
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class CooldownStore {
+  private dirty = false;
+  private lastWriteTime = 0;
+  private writeTimer: ReturnType<typeof setTimeout> | null = null;
+  private entries: Map<string, number> = new Map();
+
+  bind(entries: Map<string, number>): void {
+    this.entries = entries;
+  }
+
+  markDirty(): void {
+    this.dirty = true;
+    this.scheduleThrottledWrite();
+  }
+
+  flush(): boolean {
+    this.dirty = false;
+    this.clearWriteTimer();
+    this.lastWriteTime = Date.now();
+    return saveCooldowns(this.entries);
+  }
+
+  shutdown(): void {
+    this.clearWriteTimer();
+    if (this.dirty) {
+      saveCooldowns(this.entries);
+      this.dirty = false;
+    }
+  }
+
+  private scheduleThrottledWrite(): void {
+    if (this.writeTimer) {
+      return;
+    }
+
+    const elapsed = Date.now() - this.lastWriteTime;
+    const remaining = Math.max(0, WRITE_THROTTLE_MS - elapsed);
+
+    this.writeTimer = setTimeout(() => {
+      this.writeTimer = null;
+      this.lastWriteTime = Date.now();
+      if (this.dirty) {
+        this.dirty = false;
+        saveCooldowns(this.entries);
+      }
+    }, remaining);
+
+    if (this.writeTimer && typeof this.writeTimer === "object" && "unref" in this.writeTimer) {
+      this.writeTimer.unref();
+    }
+  }
+
+  private clearWriteTimer(): void {
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+  }
+}

--- a/src/sdk/retry/index.ts
+++ b/src/sdk/retry/index.ts
@@ -11,10 +11,25 @@ import { classifyQuotaResponse, retryInternals } from "./quota";
 import { agyFetch } from "../../fetch";
 import { CooldownStore, loadCooldowns } from "./cooldown-store";
 
-const retryCooldownByKey = loadCooldowns();
+const retryCooldownByKey = new Map<string, number>();
 const cooldownStore = new CooldownStore();
-cooldownStore.bind(retryCooldownByKey);
-const RETRY_IN_FLIGHT_LOG_INTERVAL_MS = 5000;
+let cooldownPersistenceInitialized = false;
+
+function initCooldownPersistence(): void {
+  if (cooldownPersistenceInitialized) return;
+  cooldownPersistenceInitialized = true;
+  try {
+    const persisted = loadCooldowns();
+    for (const [key, expiresAt] of persisted.entries()) {
+      retryCooldownByKey.set(key, expiresAt);
+    }
+    cooldownStore.bind(retryCooldownByKey);
+  } catch {
+    cooldownStore.bind(retryCooldownByKey);
+  }
+}
+
+export { initCooldownPersistence };
 const MODEL_CAPACITY_COOLDOWN_MS = 8000;
 
 /**
@@ -24,6 +39,7 @@ export async function fetchWithRetry(
   input: RequestInfo,
   init: RequestInit | undefined,
 ): Promise<Response> {
+  if (!cooldownPersistenceInitialized) initCooldownPersistence();
   if (!canRetryRequest(init)) {
     return agyFetch(input, init);
   }
@@ -120,6 +136,7 @@ async function waitForRetryCooldown(key: string, signal?: AbortSignal | null): P
 }
 
 function setRetryCooldown(key: string, delayMs: number): void {
+  if (!cooldownPersistenceInitialized) initCooldownPersistence();
   const next = Date.now() + delayMs;
   const current = retryCooldownByKey.get(key) ?? 0;
   retryCooldownByKey.set(key, Math.max(current, next));
@@ -127,7 +144,9 @@ function setRetryCooldown(key: string, delayMs: number): void {
 }
 
 export function shutdownRetryCooldowns(): void {
-  cooldownStore.shutdown();
+  if (cooldownPersistenceInitialized) {
+    cooldownStore.shutdown();
+  }
 }
 
 function readRequestUrl(input: RequestInfo): string {

--- a/src/sdk/retry/index.ts
+++ b/src/sdk/retry/index.ts
@@ -9,8 +9,11 @@ import {
 } from "./helpers";
 import { classifyQuotaResponse, retryInternals } from "./quota";
 import { agyFetch } from "../../fetch";
+import { CooldownStore, loadCooldowns } from "./cooldown-store";
 
-const retryCooldownByKey = new Map<string, number>();
+const retryCooldownByKey = loadCooldowns();
+const cooldownStore = new CooldownStore();
+cooldownStore.bind(retryCooldownByKey);
 const RETRY_IN_FLIGHT_LOG_INTERVAL_MS = 5000;
 const MODEL_CAPACITY_COOLDOWN_MS = 8000;
 
@@ -120,6 +123,11 @@ function setRetryCooldown(key: string, delayMs: number): void {
   const next = Date.now() + delayMs;
   const current = retryCooldownByKey.get(key) ?? 0;
   retryCooldownByKey.set(key, Math.max(current, next));
+  cooldownStore.markDirty();
+}
+
+export function shutdownRetryCooldowns(): void {
+  cooldownStore.shutdown();
 }
 
 function readRequestUrl(input: RequestInfo): string {

--- a/src/sdk/retry/index.ts
+++ b/src/sdk/retry/index.ts
@@ -24,6 +24,11 @@ function initCooldownPersistence(): void {
       retryCooldownByKey.set(key, expiresAt);
     }
     cooldownStore.bind(retryCooldownByKey);
+    if (typeof process !== "undefined") {
+      process.on("exit", () => {
+        cooldownStore.shutdown();
+      });
+    }
   } catch {
     cooldownStore.bind(retryCooldownByKey);
   }


### PR DESCRIPTION
## Persistent state tracking, SHA-256 hashing, and local plugin crash fix

### Summary

Three features plus a critical bug fix for loading this plugin as a local OpenCode plugin:

### Features

1. **Turn-state tracker with disk persistence** (`turn-state-tracker.ts`)
   - Tracks thinking/reasoning state across request turns per session
   - 24h TTL, throttled disk writes (atomic tmp+rename), graceful fallback to memory-only if disk init fails
   - `diskEnabled` constructor flag controls FS behavior

2. **SHA-256 hashing for thinking signatures** (`thinking.ts`)
   - Replaced DJB2 `hashString()` with SHA-256, truncated to 16 hex chars (`THINKING_HASH_HEX_LEN`)
   - Eliminates collision risk from the prior non-cryptographic hash

3. **Cooldown disk persistence** (`cooldown-store.ts`, `retry/index.ts`)
   - New `CooldownStore` class with `loadCooldowns()`/`saveCooldowns()` and atomic disk writes
   - Lazy `initCooldownPersistence()` defers FS reads until explicit runtime init, not import time

### Bug Fix

**Local plugin crash in Bun** - the default export was a bare function (`AgyCLIOAuthPlugin`), which caused OpenCode's V1 plugin loader to skip it and fall through to the legacy iterator. The legacy iterator treated `shutdownAgyPlugin` (a named export returning `undefined`) as a plugin, crashing Bun.

**Fix:** Default export now returns a `PluginModule` shape `{ id, server }`, and `shutdownAgyPlugin` was removed entirely.

### Hardening

- All init-time FS operations in `plugin.ts` wrapped in try/catch with `console.warn`
- `TurnStateTracker` falls back to `diskEnabled=false` (memory-only) if disk read fails
- `CooldownStore` init deferred from module-level to explicit `initCooldownPersistence()` call
- Removed unused `RETRY_IN_FLIGHT_LOG_INTERVAL_MS` constant

### Changed files (11)

| File | Change |
|------|--------|
| `index.ts` | PluginModule default export, remove `shutdownAgyPlugin` |
| `src/plugin.ts` | try/catch around all inits, remove dead import |
| `src/sdk/request/turn-state-tracker.ts` | New - TurnStateTracker with disk persistence |
| `src/sdk/request/prepare.ts` | Tracker-based thinking recovery |
| `src/sdk/request/response.ts` | Tracker wiring |
| `src/sdk/request/thinking.ts` | SHA-256, stream flags |
| `src/sdk/request/index.ts` | Re-export `initTurnStateTracker` |
| `src/sdk/retry/cooldown-store.ts` | New - CooldownStore disk persistence |
| `src/sdk/retry/index.ts` | Lazy cooldown init, remove unused constant |
| `package.json` | Version bump |
| `package-lock.json` | Lockfile update |