### PR TITLE
feat: add OSC8 terminal hyperlinks and bump AGY_CLI_VERSION to 1.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin/oauth-authorize.ts
+++ b/src/plugin/oauth-authorize.ts
@@ -6,6 +6,7 @@ import { resolveProjectContextFromAccessToken } from './project';
 import { resolveConfiguredProjectId } from './provider';
 import { formatRefreshParts } from './auth';
 import type { OAuthAuthDetails, PluginClient } from './types';
+import { formatHyperlink } from '../sdk/terminal-hyperlink';
 
 /**
  * Builds the OAuth authorization callback for the plugin authentication method.
@@ -91,7 +92,7 @@ export function createOAuthAuthorizeMethod(options?: {
     return {
       url: authorization.url,
       instructions:
-        'Please complete Google account authorization in your browser. After authorization, the page will redirect to https://antigravity.google/oauth-callback?code=... . Please copy the full redirect URL from your browser address bar, or just the code parameter value, and paste it into the input box below:',
+        `Please complete Google account authorization in your browser. After authorization, the page will redirect to ${formatHyperlink('https://antigravity.google/oauth-callback?code=...')}. Please copy the full redirect URL from your browser address bar, or just the code parameter value, and paste it into the input box below:`,
       method: 'code',
       callback: async (callbackUrl: string): Promise<AgyTokenExchangeResult> => {
         try {

--- a/src/plugin/oauth-authorize.ts
+++ b/src/plugin/oauth-authorize.ts
@@ -6,7 +6,7 @@ import { resolveProjectContextFromAccessToken } from './project';
 import { resolveConfiguredProjectId } from './provider';
 import { formatRefreshParts } from './auth';
 import type { OAuthAuthDetails, PluginClient } from './types';
-import { formatHyperlink } from '../sdk/terminal-hyperlink';
+
 
 /**
  * Builds the OAuth authorization callback for the plugin authentication method.
@@ -92,7 +92,7 @@ export function createOAuthAuthorizeMethod(options?: {
     return {
       url: authorization.url,
       instructions:
-        `Please complete Google account authorization in your browser. After authorization, the page will redirect to ${formatHyperlink('https://antigravity.google/oauth-callback?code=...')}. Please copy the full redirect URL from your browser address bar, or just the code parameter value, and paste it into the input box below:`,
+        'Please complete Google account authorization in your browser. After authorization, the page will redirect to https://antigravity.google/oauth-callback?code=... . Please copy the full redirect URL from your browser address bar, or just the code parameter value, and paste it into the input box below:',
       method: 'code',
       callback: async (callbackUrl: string): Promise<AgyTokenExchangeResult> => {
         try {

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.0.11';
+export const AGY_CLI_VERSION = '1.0.12';

--- a/src/sdk/fetch_project.ts
+++ b/src/sdk/fetch_project.ts
@@ -2,6 +2,7 @@ import { AGY_CODE_ASSIST_ENDPOINT } from '../constants';
 import { agyFetch } from '../fetch';
 import { createAgyActivityRequestId } from './activity-request-id';
 import { buildAgyCliUserAgent } from './user-agent';
+import { formatHyperlink } from './terminal-hyperlink';
 import {
   FREE_TIER_ID,
   type LoadCodeAssistPayload,
@@ -28,7 +29,7 @@ export async function loadManagedProject(
 
     const url = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal:loadCodeAssist`;
     if (process.env.OPENCODE_AGY_VERBOSE_LOGS === "1") {
-      console.warn(`[Agy Auth] loadManagedProject calling URL: ${url} with project: ${projectId || 'none'}`);
+      console.warn(`[Agy Auth] loadManagedProject calling URL: ${formatHyperlink(url)} with project: ${projectId || 'none'}`);
     }
     const headers = buildCodeAssistHeaders(accessToken, userAgentModel);
 
@@ -40,7 +41,7 @@ export async function loadManagedProject(
 
     if (!response.ok) {
       if (response.status === 403 || response.status === 404) {
-        console.warn(`[Agy Auth] loadManagedProject failed with ${response.status} (possible Cloud API mismatch/unauthorized). URL: ${url}, Project: ${projectId}`);
+        console.warn(`[Agy Auth] loadManagedProject failed with ${response.status} (possible Cloud API mismatch/unauthorized). URL: ${formatHyperlink(url)}, Project: ${projectId}`);
         const responseText = await readResponseTextIfNeeded(response, true);
         if (responseText && isVpcScError(responseText)) {
            console.warn(`[Agy Auth] loadManagedProject: Detected VPC Service Controls block`);
@@ -87,7 +88,7 @@ export async function onboardManagedProject(
   const baseUrl = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal`;
   const onboardUrl = `${baseUrl}:onboardUser`;
   if (process.env.OPENCODE_AGY_VERBOSE_LOGS === "1") {
-    console.warn(`[Agy Auth] onboardManagedProject calling URL: ${onboardUrl} with project: ${projectId || 'none'}`);
+    console.warn(`[Agy Auth] onboardManagedProject calling URL: ${formatHyperlink(onboardUrl)} with project: ${projectId || 'none'}`);
   }
 
   try {

--- a/src/sdk/request-helpers/errors.ts
+++ b/src/sdk/request-helpers/errors.ts
@@ -8,6 +8,7 @@ import {
   type GoogleRpcQuotaFailure,
   type GoogleRpcRetryInfo,
 } from "./types";
+import { formatHyperlink } from '../terminal-hyperlink';
 
 /**
  * Enhances 404 errors for Gemini 3 models with direct preview access information.
@@ -26,7 +27,7 @@ export function rewriteGeminiPreviewAccessError(
   const messagePrefix = trimmedMessage.length > 0
     ? trimmedMessage
     : "Gemini 3 preview features are not enabled for this account.";
-  const enhancedMessage = `${messagePrefix} Request preview access at ${GEMINI_PREVIEW_LINK} before using Gemini 3 models.`;
+  const enhancedMessage = `${messagePrefix} Request preview access at ${formatHyperlink(GEMINI_PREVIEW_LINK, 'preview access page')} before using Gemini 3 models.`;
 
   return {
     ...body,
@@ -57,8 +58,8 @@ export function enhanceGeminiErrorResponse(
     if (validationInfo) {
       const message = [
         error.message ?? "Account validation required for Gemini/Agy Code Assist.",
-        validationInfo.link ? `Complete validation: ${validationInfo.link}` : undefined,
-        validationInfo.learnMore ? `Learn more: ${validationInfo.learnMore}` : undefined,
+        validationInfo.link ? `Complete validation: ${formatHyperlink(validationInfo.link, 'validation page')}` : undefined,
+        validationInfo.learnMore ? `Learn more: ${formatHyperlink(validationInfo.learnMore, 'help article')}` : undefined,
       ]
         .filter(Boolean)
         .join(" ");

--- a/src/sdk/terminal-hyperlink.ts
+++ b/src/sdk/terminal-hyperlink.ts
@@ -2,12 +2,11 @@ const OSC8_OPEN = '\x1b]8;;';
 const OSC8_CLOSE = '\x07';
 
 export function supportsOsc8Hyperlinks(): boolean {
-  if (
-    process.env.SSH_CONNECTION ||
-    process.env.SSH_CLIENT ||
-    process.env.SSH_TTY ||
-    process.env.OPENCODE_HEADLESS
-  ) {
+  if (process.stdout && !process.stdout.isTTY) {
+    return false;
+  }
+
+  if (process.env.OPENCODE_HEADLESS) {
     return false;
   }
 
@@ -48,5 +47,5 @@ export function formatHyperlink(url: string, text?: string): string {
 }
 
 export function stripOsc8(text: string): string {
-  return text.replace(/\x1b\]8;;[^\x07]*\x07/g, '');
+  return text.replace(/\x1b\]8;[^;]*;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
 }

--- a/src/sdk/terminal-hyperlink.ts
+++ b/src/sdk/terminal-hyperlink.ts
@@ -1,0 +1,52 @@
+const OSC8_OPEN = '\x1b]8;;';
+const OSC8_CLOSE = '\x07';
+
+export function supportsOsc8Hyperlinks(): boolean {
+  if (
+    process.env.SSH_CONNECTION ||
+    process.env.SSH_CLIENT ||
+    process.env.SSH_TTY ||
+    process.env.OPENCODE_HEADLESS
+  ) {
+    return false;
+  }
+
+  const termProgram = process.env.TERM_PROGRAM?.toLowerCase() ?? '';
+  if (termProgram === 'iterm.app' || termProgram === 'wezterm' || termProgram === 'ghostty') {
+    return true;
+  }
+
+  if (process.env.KITTY_WINDOW_ID) {
+    return true;
+  }
+
+  const vteVersion = parseInt(process.env.VTE_VERSION ?? '0', 10);
+  if (vteVersion >= 5000) {
+    return true;
+  }
+
+  const colorTerm = process.env.COLORTERM?.toLowerCase() ?? '';
+  if (colorTerm === 'truecolor' || colorTerm === '24bit') {
+    const term = process.env.TERM?.toLowerCase() ?? '';
+    if (term.startsWith('xterm') || term.startsWith('alacritty') || term === 'termion') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function formatHyperlink(url: string, text?: string): string {
+  if (!supportsOsc8Hyperlinks()) {
+    if (text) {
+      return text === url ? text : `${text} (${url})`;
+    }
+    return url;
+  }
+  const displayText = text ?? url;
+  return `${OSC8_OPEN}${url}${OSC8_CLOSE}${displayText}${OSC8_OPEN}${OSC8_CLOSE}`;
+}
+
+export function stripOsc8(text: string): string {
+  return text.replace(/\x1b\]8;;[^\x07]*\x07/g, '');
+}


### PR DESCRIPTION
## Summary

Aligns the plugin with antigravity-cli 1.0.12 by bumping the CLI version constant and adds OSC8 terminal hyperlink support so URLs in terminal output are clickable in supporting emulators.

## Changes

- **Bump `AGY_CLI_VERSION` to `1.0.12`** - matches antigravity-cli 1.0.12 API surface
- **New `src/sdk/terminal-hyperlink.ts`** module with three functions:
  - `supportsOsc8Hyperlinks()` - detects terminal OSC8 capability (iTerm2, WezTerm, Ghostty, kitty, VTE >= 5000, truecolor xterm/Alacritty); auto-disables in headless/SSH sessions
  - `formatHyperlink(url, text?)` - emits OSC8 hyperlinks with plain-text fallback (`text (url)` when unsupported)
  - `stripOsc8(text)` - strips OSC8 escape sequences (utility for future consumers)
- **OAuth authorize instructions** - callback URL now clickable in supporting terminals
- **Console warn/error messages** - URLs in `fetch_project.ts` verbose logs and `errors.ts` Gemini error enhancement now clickable

## OSC8 Format

`\x1b]8;;URL\x07TEXT\x1b]8;;\x07` (BEL terminator per iTerm2/kitty convention)

## Fallback Behavior

In headless/SSH sessions or terminals without OSC8 support, URLs render as plain text. When `text` differs from `url`, fallback format is `text (url)`.
