### PR TITLE
fix: remove medium tier from gemini-3.1-pro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.13",
+  "version": "1.0.14-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.13",
+      "version": "1.0.14-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.13",
+  "version": "1.0.14-alpha.0",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -118,7 +118,7 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
   }
 };
 
-const TIER_MAPPING: Record<string, { low: string; medium: string; high: string } & Record<string, string>> = {
+const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string } & Record<string, string>> = {
   'gemini-3.5-flash': {
     low: 'gemini-3.5-flash-extra-low',
     medium: 'gemini-3.5-flash-low',
@@ -126,7 +126,6 @@ const TIER_MAPPING: Record<string, { low: string; medium: string; high: string }
   },
   'gemini-3.1-pro': {
     low: 'gemini-3.1-pro-low',
-    medium: 'gemini-3.1-pro-high',
     high: 'gemini-3.1-pro-high'
   }
 };
@@ -139,7 +138,7 @@ const buildModelFromSimple = (modelId: string, simple: SimpleStaticModel): Provi
   if (TIER_MAPPING[modelId]) {
     variants = {
       'low': { id: 'low', name: 'low', displayName: 'low', title: 'low', label: 'low', options: { name: 'low' }, headers: { 'x-agy-tier': 'low' } },
-      'medium': { id: 'medium', name: 'medium', displayName: 'medium', title: 'medium', label: 'medium', options: { name: 'medium' }, headers: { 'x-agy-tier': 'medium' } },
+      ...('medium' in TIER_MAPPING[modelId] ? { 'medium': { id: 'medium', name: 'medium', displayName: 'medium', title: 'medium', label: 'medium', options: { name: 'medium' }, headers: { 'x-agy-tier': 'medium' } } } : {}),
       'high': { id: 'high', name: 'high', displayName: 'high', title: 'high', label: 'high', options: { name: 'high' }, headers: { 'x-agy-tier': 'high' } }
     };
   }
@@ -291,7 +290,7 @@ function resolveModelTier(baseModelId: string, init?: RequestInit): string {
     return mapping[requestedTier] || baseModelId;
   }
 
-  return mapping['medium'];
+  return mapping['medium'] ?? mapping['high'];
 }
 
 /**

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -118,7 +118,7 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
   }
 };
 
-const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string } & Record<string, string>> = {
+const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string } & Record<string, string | undefined>> = {
   'gemini-3.5-flash': {
     low: 'gemini-3.5-flash-extra-low',
     medium: 'gemini-3.5-flash-low',
@@ -138,7 +138,7 @@ const buildModelFromSimple = (modelId: string, simple: SimpleStaticModel): Provi
   if (TIER_MAPPING[modelId]) {
     variants = {
       'low': { id: 'low', name: 'low', displayName: 'low', title: 'low', label: 'low', options: { name: 'low' }, headers: { 'x-agy-tier': 'low' } },
-      ...('medium' in TIER_MAPPING[modelId] ? { 'medium': { id: 'medium', name: 'medium', displayName: 'medium', title: 'medium', label: 'medium', options: { name: 'medium' }, headers: { 'x-agy-tier': 'medium' } } } : {}),
+      ...(TIER_MAPPING[modelId].medium !== undefined ? { 'medium': { id: 'medium', name: 'medium', displayName: 'medium', title: 'medium', label: 'medium', options: { name: 'medium' }, headers: { 'x-agy-tier': 'medium' } } } : {}),
       'high': { id: 'high', name: 'high', displayName: 'high', title: 'high', label: 'high', options: { name: 'high' }, headers: { 'x-agy-tier': 'high' } }
     };
   }


### PR DESCRIPTION
`agy` models only exposes Low and High profiles for Gemini 3.1 Pro.
Remove the medium tier mapping that silently aliased to high.
Make medium optional in `TIER_MAPPING` type, conditionally include medium variant, and default fallback to high.
