### PR TITLE
fix(auth): retry loadCodeAssist on 429 via fetchWithRetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.16",
+  "version": "1.0.17-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.0.16",
+      "version": "1.0.17-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.0.16",
+  "version": "1.0.17-alpha.0",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin/project/context.ts
+++ b/src/plugin/project/context.ts
@@ -73,6 +73,11 @@ export async function resolveProjectContextFromAccessToken(
 
   if (!loadPayload) {
     console.warn(`[Agy Auth] loadManagedProject returned null for project: ${projectId || 'none'} (possible 429 rate limit / quota exhaustion / transient backend error - not necessarily a missing project config)`);
+    if (projectId) {
+      throw new Error(
+        `Failed to load project context for '${projectId}'. This may be due to a rate limit, quota exhaustion, or transient backend error. Please try again later.`
+      );
+    }
     throw new ProjectIdRequiredError();
   }
 

--- a/src/plugin/project/context.ts
+++ b/src/plugin/project/context.ts
@@ -72,7 +72,7 @@ export async function resolveProjectContextFromAccessToken(
   }
 
   if (!loadPayload) {
-    console.warn(`[Agy Auth] loadManagedProject returned null for project: ${projectId || 'none'}`);
+    console.warn(`[Agy Auth] loadManagedProject returned null for project: ${projectId || 'none'} (possible 429 rate limit / quota exhaustion / transient backend error - not necessarily a missing project config)`);
     throw new ProjectIdRequiredError();
   }
 

--- a/src/sdk/fetch_project.ts
+++ b/src/sdk/fetch_project.ts
@@ -1,5 +1,6 @@
 import { AGY_CODE_ASSIST_ENDPOINT } from '../constants';
 import { agyFetch } from '../fetch';
+import { fetchWithRetry } from './retry';
 import { createAgyActivityRequestId } from './activity-request-id';
 import { buildAgyCliUserAgent } from './user-agent';
 import { formatHyperlink } from './terminal-hyperlink';
@@ -33,7 +34,7 @@ export async function loadManagedProject(
     }
     const headers = buildCodeAssistHeaders(accessToken, userAgentModel);
 
-    const response = await agyFetch(url, {
+    const response = await fetchWithRetry(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(requestBody)
@@ -49,7 +50,11 @@ export async function loadManagedProject(
         throw new ProjectAccessDeniedError(projectId, responseText);
       } else {
         const cleanStatusText = response.statusText.replace(/[\r\n]+/g, ' ').trim();
-        console.warn(`[Agy Auth] loadManagedProject failed with ${response.status} ${cleanStatusText}`);
+        if (response.status === 429) {
+          console.warn(`[Agy Auth] loadManagedProject failed with 429 ${cleanStatusText} (rate limited after retries; see Retry-After / quota exhaustion). URL: ${formatHyperlink(url)}, Project: ${projectId}`);
+        } else {
+          console.warn(`[Agy Auth] loadManagedProject failed with ${response.status} ${cleanStatusText}`);
+        }
       }
       return null;
     }

--- a/src/sdk/fetch_project.ts
+++ b/src/sdk/fetch_project.ts
@@ -62,6 +62,9 @@ export async function loadManagedProject(
     const responseJson = await response.json();
     return responseJson as LoadCodeAssistPayload;
   } catch (error) {
+    if (error instanceof ProjectAccessDeniedError) {
+      throw error;
+    }
     const errStr = error instanceof Error ? error.stack || error.message : String(error);
     console.warn(`[Agy Auth] Failed to load code assist project: ${errStr}`);
     return null;


### PR DESCRIPTION
loadManagedProject called agyFetch directly, bypassing the retry layer.
A mid-session 429 from Google Antigravity returned null, and the caller threw ProjectIdRequiredError, making it look like a missing project config.
Route the POST through fetchWithRetry so 429 gets exponential backoff (5s/10s/20s capped 30s), honors Retry-After and Google RetryInfo, and sets a cooldown so subsequent plugin calls within the window block instead of re-hitting. 403/404 special-casing preserved.
Also log 429 explicitly in loadManagedProject and annotate the null-payload warning in resolveProjectContextFromAccessToken so future readers do not misdiagnose rate-limit as project config.
