### PR TITLE
feat(models): add Gemini 3.6 Flash tiers and model pricing

### DIFF
--- a/models.json
+++ b/models.json
@@ -375,6 +375,39 @@
         }
       }
     },
+    "gemini-3.6-flash-low": {
+      "displayName": "Gemini 3.6 Flash (Low)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "model": "MODEL_PLACEHOLDER_M266",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true
+    },
+    "gemini-3.6-flash-medium": {
+      "displayName": "Gemini 3.6 Flash (Medium)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "model": "MODEL_PLACEHOLDER_M265",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true
+    },
+    "gemini-3.6-flash-high": {
+      "displayName": "Gemini 3.6 Flash (High)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "model": "MODEL_PLACEHOLDER_M264",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true
+    },
     "gemini-3-flash-agent": {
       "displayName": "Gemini 3.5 Flash (High)",
       "supportsImages": true,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -78,7 +78,15 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
     maxOutputTokens: 65536,
     toolCall: true,
     reasoning: true,
-    attachment: true
+    attachment: true,
+    cost: {
+      input: 1.5,
+      output: 9,
+      cache: {
+        read: 0.15,
+        write: 0
+      }
+    }
   },
   'gemini-3.1-pro': {
     name: 'Gemini 3.1 Pro',
@@ -87,7 +95,15 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
     maxOutputTokens: 65535,
     toolCall: true,
     reasoning: true,
-    attachment: true
+    attachment: true,
+    cost: {
+      input: 2,
+      output: 12,
+      cache: {
+        read: 0.2,
+        write: 0.375
+      }
+    }
   },
   'claude-sonnet-4-6': {
     name: 'Claude Sonnet 4.6 (Thinking)',
@@ -96,7 +112,15 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
     maxOutputTokens: 64000,
     toolCall: true,
     reasoning: true,
-    attachment: true
+    attachment: true,
+    cost: {
+      input: 3,
+      output: 15,
+      cache: {
+        read: 0.3,
+        write: 3.75
+      }
+    }
   },
   'claude-opus-4-6-thinking': {
     name: 'Claude Opus 4.6 (Thinking)',
@@ -105,7 +129,15 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
     maxOutputTokens: 64000,
     toolCall: true,
     reasoning: true,
-    attachment: true
+    attachment: true,
+    cost: {
+      input: 5,
+      output: 25,
+      cache: {
+        read: 0.5,
+        write: 6.25
+      }
+    }
   },
   'gpt-oss-120b-medium': {
     name: 'GPT-OSS 120B (Medium)',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -71,6 +71,23 @@ interface SimpleStaticModel {
 }
 
 const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
+  'gemini-3.6-flash': {
+    name: 'Gemini 3.6 Flash',
+    description: 'Gemini 3.6 Flash with low, medium, and high reasoning tiers.',
+    maxTokens: 1048576,
+    maxOutputTokens: 65536,
+    toolCall: true,
+    reasoning: true,
+    attachment: true,
+    cost: {
+      input: 1.5,
+      output: 7.5,
+      cache: {
+        read: 0.15,
+        write: 0.083333
+      }
+    }
+  },
   'gemini-3.5-flash': {
     name: 'Gemini 3.5 Flash',
     description: 'Gemini 3.5 Flash base model. Select tier at runtime.',
@@ -151,6 +168,11 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
 };
 
 const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string } & Record<string, string | undefined>> = {
+  'gemini-3.6-flash': {
+    low: 'gemini-3.6-flash-low',
+    medium: 'gemini-3.6-flash-medium',
+    high: 'gemini-3.6-flash-high'
+  },
   'gemini-3.5-flash': {
     low: 'gemini-3.5-flash-extra-low',
     medium: 'gemini-3.5-flash-low',


### PR DESCRIPTION
## Summary
- Add cost metadata for Gemini 3.5 Flash, Gemini 3.1 Pro, Claude Sonnet 4.6, and Claude Opus 4.6.
- Add Gemini 3.6 Flash with low, medium, and high tiers.
- Map tiers to verified Antigravity backend enums.

## Verification
- `npm run typecheck`
- `npm run build`
- `npm run smoke:node-import`