### PR TITLE
fix(agy): map gemini-3.5-flash tiers to live server ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.5",
+  "version": "1.1.6-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.1.5",
+      "version": "1.1.6-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.5",
+  "version": "1.1.6-alpha.0",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -134,9 +134,9 @@ const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string 
     high: 'gemini-3.6-flash-high'
   },
   'gemini-3.5-flash': {
-    low: 'gemini-3.5-flash-low',
-    medium: 'gemini-3.5-flash-medium',
-    high: 'gemini-3.5-flash-high'
+    low: 'gemini-3.5-flash-extra-low',
+    medium: 'gemini-3.5-flash-low',
+    high: 'gemini-3-flash-agent'
   },
   'gemini-3.1-pro': {
     low: 'gemini-3.1-pro-low',

--- a/src/sdk/request/shared.ts
+++ b/src/sdk/request/shared.ts
@@ -3,6 +3,14 @@ import { AGY_GENERATIVE_LANGUAGE_ENDPOINT } from "../../constants";
 const REQUEST_MODEL_FALLBACKS: Record<string, string> = {
   "gemini-2.5-flash-image": "gemini-2.5-flash",
   "gemini-3.1-pro-high": "gemini-pro-agent",
+  // Safety net: the gemini-3.5-flash-low/medium/high tier ids no longer
+  // exist server-side. If any stale URL still contains them, remap to the
+  // current live ids. Primary fix is TIER_MAPPING in plugin.ts.
+  //   medium -> gemini-3.5-flash-low        (enum M20,  display "Gemini 3.5 Flash (Medium)")
+  //   high   -> gemini-3-flash-agent        (enum M84,  display "Gemini 3.5 Flash (High)")
+  //   low    -> gemini-3.5-flash-extra-low  (enum M187, display "Gemini 3.5 Flash (Low)")
+  "gemini-3.5-flash-medium": "gemini-3.5-flash-low",
+  "gemini-3.5-flash-high": "gemini-3-flash-agent",
 };
 const GENERATIVE_LANGUAGE_HOST = new URL(AGY_GENERATIVE_LANGUAGE_ENDPOINT).host;
 const CODE_ASSIST_HOST_SUFFIX = "cloudcode-pa.googleapis.com";


### PR DESCRIPTION
Server-side tieredModelIds revoked gemini-3.5-flash-low/medium/high and replaced with gemini-3.5-flash-extra-low, gemini-3.5-flash-low, and gemini-3-flash-agent. The plugin's TIER_MAPPING still sent dead ids to v1internal:streamGenerateContent, triggering 'Requested entity was not found.' Add safety-net fallbacks for any stale tier ids still cached.
