### PR TITLE
feat: implement dynamic model cost resolver via models.dev API

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -328,7 +328,7 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
   let latestConfig: Config | undefined;
 
   // Dynamically update STATIC_MODELS with latest pricing from models.dev
-  await updateStaticModelsWithPricing(STATIC_MODELS);
+  updateStaticModelsWithPricing(STATIC_MODELS);
 
   const getModelsList = (provider: ProviderV2): Record<string, ProviderModel> => {
     const userModels = provider.models || {};

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -619,7 +619,14 @@ export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<Plug
           };
         }
 
-        return getModelsList(provider);
+        const models = getModelsList(provider);
+        // Ensure dynamic pricing costs are strictly enforced to override any cached $0 fallbacks
+        for (const [modelId, model] of Object.entries(models)) {
+          if (STATIC_MODELS[modelId] && STATIC_MODELS[modelId].cost) {
+            model.cost = STATIC_MODELS[modelId].cost;
+          }
+        }
+        return models;
       }
     } as any
   };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,4 @@
+import { updateStaticModelsWithPricing } from './plugin/pricing';
 import type { Config } from './plugin/types';
 import { AGY_PROVIDER_ID } from './constants';
 import { agyFetch } from './fetch';
@@ -325,6 +326,9 @@ function resolveModelTier(baseModelId: string, init?: RequestInit): string {
  */
 export const AgyCLIOAuthPlugin = async ({ client }: PluginContext): Promise<PluginResult> => {
   let latestConfig: Config | undefined;
+
+  // Dynamically update STATIC_MODELS with latest pricing from models.dev
+  await updateStaticModelsWithPricing(STATIC_MODELS);
 
   const getModelsList = (provider: ProviderV2): Record<string, ProviderModel> => {
     const userModels = provider.models || {};

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -1,0 +1,125 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import type { ProviderModel } from './types';
+
+// Using fetch API (available in Node.js 18+)
+const PRICING_API_URL = 'https://models.dev/api.json';
+const CACHE_FILE_NAME = 'agy-pricing-cache.json';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface ModelsDevCost {
+  input?: number;
+  output?: number;
+  cache_read?: number;
+  cache_write?: number;
+  [key: string]: any;
+}
+
+interface ModelsDevModel {
+  cost?: ModelsDevCost;
+  [key: string]: any;
+}
+
+interface ModelsDevProvider {
+  models: Record<string, ModelsDevModel>;
+  [key: string]: any;
+}
+
+type ModelsDevResponse = Record<string, ModelsDevProvider>;
+
+function getCachePath(): string {
+  return join(tmpdir(), CACHE_FILE_NAME);
+}
+
+function loadCachedPricing(): ModelsDevResponse | null {
+  try {
+    const cachePath = getCachePath();
+    if (!existsSync(cachePath)) return null;
+
+    const stats = statSync(cachePath);
+    if (Date.now() - stats.mtimeMs > CACHE_TTL_MS) {
+      return null; // Cache expired
+    }
+
+    const data = readFileSync(cachePath, 'utf-8');
+    return JSON.parse(data) as ModelsDevResponse;
+  } catch (err) {
+    return null;
+  }
+}
+
+function savePricingCache(data: ModelsDevResponse): void {
+  try {
+    const cachePath = getCachePath();
+    writeFileSync(cachePath, JSON.stringify(data), 'utf-8');
+  } catch (err) {
+    // Ignore cache write errors
+  }
+}
+
+async function fetchPricing(): Promise<ModelsDevResponse | null> {
+  const cached = loadCachedPricing();
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await fetch(PRICING_API_URL);
+    if (!response.ok) {
+      return null;
+    }
+    const data = (await response.json()) as ModelsDevResponse;
+    if (data) {
+      savePricingCache(data);
+      return data;
+    }
+  } catch (err) {
+    // Silent fail, will fallback to 0 or existing costs
+  }
+
+  return null;
+}
+
+function determineProvider(modelId: string): string | null {
+  const lower = modelId.toLowerCase();
+  if (lower.startsWith('gemini-') || lower.startsWith('gemma-')) return 'google';
+  if (lower.startsWith('claude-')) return 'anthropic';
+  if (lower.startsWith('gpt-') || lower.startsWith('o1') || lower.startsWith('o3')) return 'openai';
+  return null;
+}
+
+/**
+ * Mutates the STATIC_MODELS object by injecting dynamic costs from models.dev
+ */
+export async function updateStaticModelsWithPricing(
+  staticModels: Record<string, ProviderModel>
+): Promise<void> {
+  const pricingData = await fetchPricing();
+  if (!pricingData) return;
+
+  for (const [modelId, modelObj] of Object.entries(staticModels)) {
+    const provider = determineProvider(modelId);
+    if (!provider || !pricingData[provider]?.models) continue;
+
+    // Remove the "-thinking" suffix which is custom for opencode if the base model exists
+    let lookupId = modelId;
+    if (lookupId.endsWith('-thinking') && !pricingData[provider].models[lookupId]) {
+      lookupId = lookupId.replace('-thinking', '');
+    }
+
+    const apiModel = pricingData[provider].models[lookupId];
+    if (apiModel && apiModel.cost) {
+      const apiCost = apiModel.cost;
+      
+      modelObj.cost = {
+        input: apiCost.input ?? modelObj.cost?.input ?? 0,
+        output: apiCost.output ?? modelObj.cost?.output ?? 0,
+        cache: {
+          read: apiCost.cache_read ?? modelObj.cost?.cache?.read ?? 0,
+          write: apiCost.cache_write ?? modelObj.cost?.cache?.write ?? 0
+        }
+      };
+    }
+  }
+}

--- a/src/plugin/pricing.ts
+++ b/src/plugin/pricing.ts
@@ -1,4 +1,4 @@
-import { tmpdir } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
 import { join } from 'node:path';
 import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import type { ProviderModel } from './types';
@@ -7,6 +7,8 @@ import type { ProviderModel } from './types';
 const PRICING_API_URL = 'https://models.dev/api.json';
 const CACHE_FILE_NAME = 'agy-pricing-cache.json';
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+let memoryCache: ModelsDevResponse | null = null;
 
 interface ModelsDevCost {
   input?: number;
@@ -29,7 +31,11 @@ interface ModelsDevProvider {
 type ModelsDevResponse = Record<string, ModelsDevProvider>;
 
 function getCachePath(): string {
-  return join(tmpdir(), CACHE_FILE_NAME);
+  try {
+    return join(tmpdir(), `${CACHE_FILE_NAME}-${userInfo().uid}`);
+  } catch (err) {
+    return join(tmpdir(), CACHE_FILE_NAME);
+  }
 }
 
 function loadCachedPricing(): ModelsDevResponse | null {
@@ -59,22 +65,34 @@ function savePricingCache(data: ModelsDevResponse): void {
 }
 
 async function fetchPricing(): Promise<ModelsDevResponse | null> {
+  if (memoryCache) {
+    return memoryCache;
+  }
+
   const cached = loadCachedPricing();
   if (cached) {
+    memoryCache = cached;
     return cached;
   }
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2000);
+
   try {
-    const response = await fetch(PRICING_API_URL);
+    const response = await fetch(PRICING_API_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+
     if (!response.ok) {
       return null;
     }
     const data = (await response.json()) as ModelsDevResponse;
     if (data) {
       savePricingCache(data);
+      memoryCache = data;
       return data;
     }
   } catch (err) {
+    clearTimeout(timeoutId);
     // Silent fail, will fallback to 0 or existing costs
   }
 
@@ -92,34 +110,37 @@ function determineProvider(modelId: string): string | null {
 /**
  * Mutates the STATIC_MODELS object by injecting dynamic costs from models.dev
  */
-export async function updateStaticModelsWithPricing(
+export function updateStaticModelsWithPricing(
   staticModels: Record<string, ProviderModel>
-): Promise<void> {
-  const pricingData = await fetchPricing();
-  if (!pricingData) return;
+): void {
+  fetchPricing().then((pricingData) => {
+    if (!pricingData) return;
 
-  for (const [modelId, modelObj] of Object.entries(staticModels)) {
-    const provider = determineProvider(modelId);
-    if (!provider || !pricingData[provider]?.models) continue;
+    for (const [modelId, modelObj] of Object.entries(staticModels)) {
+      const provider = determineProvider(modelId);
+      if (!provider || !pricingData[provider]?.models) continue;
 
-    // Remove the "-thinking" suffix which is custom for opencode if the base model exists
-    let lookupId = modelId;
-    if (lookupId.endsWith('-thinking') && !pricingData[provider].models[lookupId]) {
-      lookupId = lookupId.replace('-thinking', '');
+      // Remove the "-thinking" suffix which is custom for opencode if the base model exists
+      let lookupId = modelId;
+      if (lookupId.endsWith('-thinking') && !pricingData[provider].models[lookupId]) {
+        lookupId = lookupId.replace('-thinking', '');
+      }
+
+      const apiModel = pricingData[provider].models[lookupId];
+      if (apiModel && apiModel.cost) {
+        const apiCost = apiModel.cost;
+        
+        modelObj.cost = {
+          input: apiCost.input ?? modelObj.cost?.input ?? 0,
+          output: apiCost.output ?? modelObj.cost?.output ?? 0,
+          cache: {
+            read: apiCost.cache_read ?? modelObj.cost?.cache?.read ?? 0,
+            write: apiCost.cache_write ?? modelObj.cost?.cache?.write ?? 0
+          }
+        };
+      }
     }
-
-    const apiModel = pricingData[provider].models[lookupId];
-    if (apiModel && apiModel.cost) {
-      const apiCost = apiModel.cost;
-      
-      modelObj.cost = {
-        input: apiCost.input ?? modelObj.cost?.input ?? 0,
-        output: apiCost.output ?? modelObj.cost?.output ?? 0,
-        cache: {
-          read: apiCost.cache_read ?? modelObj.cost?.cache?.read ?? 0,
-          write: apiCost.cache_write ?? modelObj.cost?.cache?.write ?? 0
-        }
-      };
-    }
-  }
+  }).catch(() => {
+    // Ignore errors to prevent unhandled rejections
+  });
 }


### PR DESCRIPTION
This PR introduces a dynamic pricing fetcher that automatically retrieves the latest model costs from the `models.dev` API registry. 

**Key Improvements:**
- **Zero Hardcoding:** Eliminates the need to manually hardcode and update prices for Google, Anthropic, and OpenAI models inside the plugin.
- **Dynamic Provider Mapping:** Automatically maps OpenCode model IDs to their respective providers in the API registry.
- **Smart Caching:** Responses are securely cached in the OS `tmpdir` with a 24-hour TTL to ensure CLI boot times remain instant without unnecessary network overhead.
- **Conflict-Free:** Designed to be completely modular and will seamlessly merge alongside other pending PRs (e.g., model capabilities alignment).