### PR TITLE
fix(agy): override minimal variant to bypass M16 budget:0 rejection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.7",
+  "version": "1.1.8-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.1.7",
+      "version": "1.1.8-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.7",
+  "version": "1.1.8-alpha.0",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -130,11 +130,13 @@ const STATIC_MODELS_SIMPLE: Record<string, SimpleStaticModel> = {
 
 const TIER_MAPPING: Record<string, { low: string; high: string; medium?: string } & Record<string, string | undefined>> = {
   'gemini-3.6-flash': {
+    minimal: 'gemini-3.6-flash-low',
     low: 'gemini-3.6-flash-low',
     medium: 'gemini-3.6-flash-medium',
     high: 'gemini-3.6-flash-high'
   },
   'gemini-3.5-flash': {
+    minimal: 'gemini-3.5-flash-extra-low',
     low: 'gemini-3.5-flash-extra-low',
     medium: 'gemini-3.5-flash-low',
     high: 'gemini-3-flash-agent'
@@ -151,7 +153,17 @@ const buildModelFromSimple = (modelId: string, simple: SimpleStaticModel): Provi
 
   let variants: any = undefined;
   if (TIER_MAPPING[modelId]) {
+    const hasMinimal = TIER_MAPPING[modelId].minimal !== undefined;
     variants = {
+      ...(hasMinimal ? {
+        'minimal': {
+          id: 'minimal', name: 'minimal', displayName: 'minimal',
+          title: 'minimal', label: 'minimal',
+          options: { name: 'minimal' },
+          headers: { 'x-agy-tier': 'minimal' },
+          thinkingConfig: { thinkingBudget: 1000, includeThoughts: true }
+        }
+      } : {}),
       'low': { id: 'low', name: 'low', displayName: 'low', title: 'low', label: 'low', options: { name: 'low' }, headers: { 'x-agy-tier': 'low' } },
       ...(TIER_MAPPING[modelId].medium !== undefined ? { 'medium': { id: 'medium', name: 'medium', displayName: 'medium', title: 'medium', label: 'medium', options: { name: 'medium' }, headers: { 'x-agy-tier': 'medium' } } } : {}),
       'high': { id: 'high', name: 'high', displayName: 'high', title: 'high', label: 'high', options: { name: 'high' }, headers: { 'x-agy-tier': 'high' } }

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -305,11 +305,12 @@ function normalizeThinking(
     requestPayload.thinkingConfig,
     rawGenerationConfig?.thinkingConfig,
   );
-  const normalizedThinkingConfig = normalizeThinkingConfig(mergedThinkingConfig);
 
   if (Object.prototype.hasOwnProperty.call(requestPayload, "thinkingConfig")) {
     delete requestPayload.thinkingConfig;
   }
+
+  const normalizedThinkingConfig = normalizeThinkingConfig(mergedThinkingConfig);
 
   if (!normalizedThinkingConfig) {
     if (rawGenerationConfig) {


### PR DESCRIPTION
opencode injects a 'minimal' variant with thinkingLevel:'minimal' as the first small/title-agent option. 
plugin's thinking.ts maps MINIMAL to thinkingBudget:0, which M16 backends reject as INVALID_ARGUMENT. 

Declaring our own minimal variant with explicit thinkingBudget:1000 overrides opencode's auto-injected one via mergeDeep and stays within M16's declared cap.
