### PR TITLE
chore: bump agy cli to 1.1.8 and update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,51 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.8-alpha.0",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.1.8-alpha.0",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
+        "@ai-sdk/google": "^4.0.26",
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.18.5"
+        "@opencode-ai/plugin": "^1.18.8"
       },
       "devDependencies": {
-        "@opencode-ai/sdk": "^1.18.5",
-        "@types/node": "^26.1.1",
+        "@opencode-ai/sdk": "^1.18.8",
+        "@types/node": "^26.1.2",
         "tsup": "^8.5.1",
         "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.27.tgz",
+      "integrity": "sha512-u44UuLypwwHqEaHPRV1iZ1N+xO9dCKzQX6L2DtPPxvlsSdSzNobUBz8oaDv6NzC35qYSb6JFs7TG1Tz2Nxlg/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -30,6 +59,42 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.14.tgz",
+      "integrity": "sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -605,13 +670,13 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.5.tgz",
-      "integrity": "sha512-o1loQw5lh3zK7dgTN25Zh4tK+bW7BdszyDwdSumj0ahaR1lXWjYjVbAZuOQxeEQfkr266cqNi2x8UrrlkI0n7A==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.9.tgz",
+      "integrity": "sha512-0kFX9Usj+3N+WupIe9VnEdDNzMNbW4/C5GeIzdj02/t5kQoXsNrFpW3Br9aABebazcaYsQEWdlaLV0zQISy3OA==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.5",
+        "@opencode-ai/sdk": "1.18.9",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -633,9 +698,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.5.tgz",
-      "integrity": "sha512-7KgMvP5/1oxbhHj6kYBtPSTEdFKYpUeEYOzBTKdzSaRpapUpFFdn6Hkus3rr0rljO0kukWZIgRd3DrVBwTULGA==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.9.tgz",
+      "integrity": "sha512-oDJSmsmiGW+3lNLmZYj3EpUkpiT3ITZBKffH3mrmu2KMJXlkxQ/Nvv7jqPffSM7o8lCdBZS/aCE+2GkA3/92gQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1096,9 +1161,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1445,6 +1510,12 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1658,6 +1729,15 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/fast-check": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.8-alpha.0",
+  "version": "1.1.8",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -25,13 +25,14 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@opencode-ai/sdk": "^1.18.5",
-    "@types/node": "^26.1.1",
+    "@opencode-ai/sdk": "^1.18.8",
+    "@types/node": "^26.1.2",
     "tsup": "^8.5.1",
     "typescript": "^7.0.2"
   },
   "dependencies": {
+    "@ai-sdk/google": "^4.0.26",
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.18.5"
+    "@opencode-ai/plugin": "^1.18.8"
   }
 }

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.7';
+export const AGY_CLI_VERSION = '1.1.8';


### PR DESCRIPTION
- agy cli version 1.1.7 -> 1.1.8 (cli/tui-only release)
- add @ai-sdk/google ^4.0.26 as direct dep for stable gemini model id resolution
- bump @opencode-ai/sdk + plugin to ^1.18.8
- bump @types/node to ^1.18.8
