### PR TITLE
chore: bump agy cli to 1.1.12 and update deps

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.11"
+      "release-as": "1.1.12"
     }
   },
   "changelog-types": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md
+
+OpenCode plugin that adds the Google Gemini Antigravity CLI (`agy`) OAuth provider. This plugin intercepts `fetch()` calls from `@ai-sdk/google` and rewrites them to the Antigravity Code Assist endpoint with OAuth bearer auth, project context resolution, and server-supplied model enum mapping. The plugin ships its own `agy_quota` and `agy_quota_summary` tools.
+
+## agy CLI bump workflow
+
+When a new `agy` CLI release lands (check `https://github.com/google-antigravity/antigravity-cli/releases`):
+
+1. Install or upgrade the CLI locally so `agy --version` matches the target release.
+2. Read the release notes at `https://github.com/google-antigravity/antigravity-cli/releases/tag/<VERSION>` and reconcile every item against the plugin's surface. Most agy CLI releases are client-only UI/UX work (Vim mode, artifact rendering, terminal hyperlinks) or local filesystem fixes (atomic config writes, keyring timeouts) and require no plugin change.
+3. Update `src/sdk/agy-cli-version.ts` to the new version. This single constant feeds `buildAgyCliUserAgent()` in `src/sdk/user-agent.ts`, which sets the `User-Agent` header on every Code Assist API request the plugin makes. Aligning it with the installed CLI keeps server-side attribution consistent.
+4. Update `package.json` line 3 (`"version"`) to the new version.
+5. Update `.release-please-config.json` (`"release-as"` field) to the new version. Do **not** touch `.release-please-manifest.json`; release-please manages it automatically on PR merge.
+6. Run `npm outdated` and bump dependencies to latest semver-compatible. `@ai-sdk/google` is never imported by the plugin; it is only referenced as a literal npm-name string in `src/plugin.ts:179` and `src/plugin.ts:438`, so version bumps are zero-risk.
+7. Refresh `models.json` from a live `fetchAvailableModels` call (see below).
+8. Run `npm install && npm run typecheck && npm run build && npm run smoke:node-import`.
+
+Prior bump commits follow a consistent pattern. Run `git log --oneline | grep "bump agy cli"` for examples.
+
+## Refreshing models.json
+
+`models.json` is the Antigravity Code Assist internal model catalog returned by the `fetchAvailableModels` server API. It is **not** the same as the public-facing `agy models` command output, which is a filtered subset. The plugin's `src/sdk/request/prepare.ts` reads `models.json` at runtime to resolve model enum placeholders via `getModelEnum`.
+
+To refresh:
+
+```bash
+npm run models:refresh
+```
+
+Or equivalently:
+
+```bash
+./scripts/fetch-models.mjs --verbose
+```
+
+The script:
+
+1. Reads `~/.local/share/opencode/auth.json` and extracts the `google-agy.refresh` field, whose format is `refreshToken|projectId|managedProjectId`.
+2. Refreshes the OAuth access token via `POST https://oauth2.googleapis.com/token` using `AGY_CLIENT_ID` and `AGY_CLIENT_SECRET` (same values as `src/constants.ts`).
+3. Calls `POST https://daily-cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels` with body `{"project": managedProjectId}`.
+4. Writes the response (pretty-printed, 2-space indent) to `models.json` at the repo root.
+
+Flags:
+
+- `--endpoint <url>`: override the Code Assist endpoint (default `https://daily-cloudcode-pa.googleapis.com`).
+- `--output <path>`: write to a different file (default `models.json` at repo root).
+- `--verbose`: emit progress to stderr.
+
+The script uses Node's built-in `fetch` (HTTP/2 capable). This is required because curl's HTTP/1.0 fallback fails due to network-level stream resets when sending the `Authorization` header against Google APIs from certain network environments; Node's HTTP/2 stream multiplexing handles it correctly.
+
+### Verifying a refresh
+
+After running `models:refresh`, diff old vs new `models.json` to identify:
+
+- Model additions or removals in `.models` keys.
+- Changes to `.defaultAgentModelId` (the agy CLI's default model).
+- Changes to `.tieredModelIds.flash` (the tiered-flash parent model id, rotates across releases).
+- New `.deprecatedModelIds` entries (model enum migrations).
+- Changes to `.agentModelSorts[0].groups[0].modelIds` (the user-visible recommended list).
+
+Always verify that `.deprecatedModelIds` for `gemini-3.1-pro-high` (mapping to `gemini-pro-agent` with enum `MODEL_PLACEHOLDER_M16`) is preserved. The plugin's `src/sdk/request/shared.ts:10` hardcodes a fallback rewrite of `gemini-3.1-pro-high` to `gemini-pro-agent`, which depends on this deprecation entry being present in `models.json` so `prepare.ts` `getModelEnum` resolves the correct enum.
+
+## Surface review checklist
+
+When reconciling agy CLI release notes against this plugin's code surface, check:
+
+- `src/sdk/agy-cli-version.ts` - version constant
+- `src/constants.ts` - client ID/secret, endpoints, OAuth scopes
+- `src/sdk/user-agent.ts` - User-Agent builder using `AGY_CLI_VERSION`
+- `src/sdk/request/prepare.ts` - request body transformation, `getModelEnum` reads from `models.json`
+- `src/sdk/request/shared.ts` - model fallback rewrites (e.g., `gemini-3.1-pro-high` to `gemini-pro-agent`)
+- `src/sdk/fetch_models.ts` - `fetchAvailableModels` endpoint interface (do not confuse with the `agy models` CLI command output)
+- `src/sdk/fetch_quota.ts` - quota fetch helpers
+- `src/sdk/retry/quota.ts` - quota classification (parses server-supplied `RetryInfo`)
+- `src/sdk/retry/helpers.ts` - retry delay resolution (prioritizes `retry-after-ms`, then `retry-after`, then `parseRetryDelayFromBody`)
+- `src/plugin.ts` - `STATIC_MODELS_SIMPLE`, `TIER_MAPPING`, fetch interceptor, provider registration
+- `src/plugin/pricing.ts` - dynamic model cost resolution via models.dev
+- `src/plugin/project/context.ts` - project context resolution (loadCodeAssist / onboardUser)
+- `src/plugin/quota.ts` and `src/plugin/quota-summary.ts` - the agy_quota and agy_quota_summary tools
+- `models.json` - internal server model catalog (different from `agy models` public-facing output)
+
+## Important distinctions
+
+- `agy models` (or `agy --output-format stream-json models`) returns the public-facing filtered model IDs (e.g., `gemini-3.5-flash-low`). This is the list users see in the CLI's model picker.
+- The `fetchAvailableModels` API returns the full internal catalog including preview/internal models (e.g., `chat_20706`, `tab_flash_lite_preview`, `gemini-3.6-flash-tiered` with no `displayName`). This is what the plugin's `prepare.ts` reads at runtime.
+- Only `models.json` is used by the plugin at runtime; the `agy models` output is informational and not consumed by the plugin code.
+- `@ai-sdk/google` is never imported; it is only used as a literal npm-name string at `src/plugin.ts:179` and `src/plugin.ts:438`. Version bumps to this package are zero-risk regardless of API changes in the upstream package.
+- The plugin's OAuth token storage lives at `~/.local/share/opencode/auth.json` under the `google-agy` key. The agy CLI itself uses the OS keyring directly; the opencode plugin maintains its own auth storage for portability.
+
+## Gotchas
+
+- `.release-please-manifest.json` is auto-managed by release-please; do not manually edit it.
+- When the agy CLI is not logged in (`agy --version` works but `agy` interactive fails with "could not open TTY"), the `agy models` command still works and returns a cached or session-less model list.
+- curl may show `HTTP/1.0 400 Bad Request` from a network security appliance intercepting `Authorization`-header requests against Google APIs. Use Node `fetch` instead (HTTP/2 stream multiplexing works correctly through such appliances). This is why `scripts/fetch-models.mjs` uses Node's built-in `fetch` rather than shelling out to `curl`.
+- The `managedProjectId` (third pipe-separated field of the refresh token, e.g., `citric-engine-kl9s4`) is the value passed as the `project` body parameter to `fetchAvailableModels`, not the user-facing project ID. The user-facing project ID (second field, e.g., `tone-workspace-cli`) is not directly accepted by the API.
+- A fresh `fetchAvailableModels` response will overwrite the entire `models.json` file. Diff old vs new before committing to catch any unintended server-side removals. Pay particular attention to the `deprecatedModelIds` entry for `gemini-3.1-pro-high` which the plugin's `shared.ts:10` fallback depends on.
+
+## Build verification
+
+```bash
+npm install          # updates package-lock.json
+npm run typecheck    # tsc type check
+npm run build        # tsup bundle + tsc declaration emit
+npm run smoke:node-import  # verify dist/index.js loads without error
+```
+
+Validate `models.json` is well-formed JSON:
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('models.json', 'utf8')); console.log('ok')"
+```

--- a/models.json
+++ b/models.json
@@ -1,22 +1,260 @@
 {
   "models": {
-    "tab_jump_flash_lite_preview": {
+    "gemini-3.1-pro-low": {
+      "displayName": "Gemini 3.1 Pro (Low)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": 1001,
+      "minThinkingBudget": 128,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65535,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M36",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "supportedMimeTypes": {
+        "application/x-ipynb+json": true,
+        "application/rtf": true,
+        "image/heic": true,
+        "image/heif": true,
+        "application/pdf": true,
+        "text/css": true,
+        "application/x-javascript": true,
+        "image/webp": true,
+        "video/audio/s16le": true,
+        "video/jpeg2000": true,
+        "application/x-typescript": true,
+        "video/webm": true,
+        "image/jpeg": true,
+        "text/markdown": true,
+        "text/javascript": true,
+        "text/x-python-script": true,
+        "video/audio/wav": true,
+        "video/videoframe/jpeg2000": true,
+        "text/plain": true,
+        "image/png": true,
+        "text/x-python": true,
+        "video/text/timestamp": true,
+        "audio/webm;codecs=opus": true,
+        "text/rtf": true,
+        "video/mp4": true,
+        "application/json": true,
+        "text/x-typescript": true,
+        "application/x-python-code": true,
+        "text/html": true,
+        "text/xml": true,
+        "text/csv": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "template__system_prompts__planning_mode_artifacts": {
+            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
+          },
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": true,\n    \"disabledHeuristics\": [\"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
+          },
+          "template__system_prompts__communication_style": {
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [filename](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n\nCRITICAL INSTRUCTION 1: You may have access to a variety of tools at your disposal. Some tools may be for a specific task such as 'view_file' (for viewing contents of a file). Others may be very broadly applicable such as the ability to run a command on a terminal. Always prioritize using the most specific tool you can for the task at hand. Here are some rules: (a) NEVER run cat inside a bash command to create a new file or append to an existing file. (b) ALWAYS use grep_search instead of running grep inside a bash command unless absolutely needed. (c) DO NOT use ls for listing, cat for viewing, grep for finding, sed for replacing.\nCRITICAL INSTRUCTION 2: Before making tool calls T, think and explicitly list out any related tools for the task at hand. You can only execute a set of tools T if all other tools in the list are either more generic or cannot be used for the task at hand. ALWAYS START your thought with recalling critical instructions 1 and 2. In particular, the format for the start of your thought block must be '...94>thought\\nCRITICAL INSTRUCTION 1: ...\\nCRITICAL INSTRUCTION 2: ...'."
+          }
+        }
+      }
+    },
+    "gemini-3-flash-agent": {
+      "displayName": "Gemini 3.5 Flash (High)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": -1,
+      "minThinkingBudget": 32,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M47",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "tagTitle": "Fast",
+      "tagDescription": "Limited time",
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/rtf": true,
+        "text/javascript": true,
+        "text/csv": true,
+        "video/audio/s16le": true,
+        "application/x-javascript": true,
+        "application/x-typescript": true,
+        "image/webp": true,
+        "audio/webm;codecs=opus": true,
+        "image/png": true,
+        "application/pdf": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "image/heif": true,
+        "text/html": true,
+        "application/x-python-code": true,
+        "text/xml": true,
+        "text/markdown": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "image/jpeg": true,
+        "video/videoframe/jpeg2000": true,
+        "text/plain": true,
+        "image/heic": true,
+        "text/css": true,
+        "video/mp4": true,
+        "text/x-python-script": true,
+        "video/webm": true,
+        "video/text/timestamp": true,
+        "text/x-typescript": true,
+        "application/x-ipynb+json": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "template__system_prompts__messaging": {
+            "stringValue": "You are connected to a messaging system where you may receive messages from: {{- $subagent := .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled -}}\n{{- $message := .CascadeConfig.GetMessageConfig.GetEnabled -}}\n{{- if and $subagent $message }} agents, background tasks, user-queued messages\n{{- else if $subagent }} agents, background tasks\n{{- else if $message }} background tasks, user-queued messages\n{{- else }} background tasks\n{{- end }}.\n\n## Receiving Messages\n\nYou receive messages automatically at the start of each invocation. All messages are delivered in full directly into your context — no manual retrieval is needed.\n\n## Reactive Wakeup (No Polling Needed)\n\nThe system automatically resumes your execution when:\n{{- if .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled }}\n- A message arrives from a subagent or peer agent\n{{- end }}\n- A **background task** completes or sends you a notification\n{{- if .CascadeConfig.GetMessageConfig.GetEnabled }}\n- A **user-queued message** is ready to be dequeued\n{{- end }}\n\nThis means you do **NOT** need to poll in a loop while waiting for messages or updates. After launching a task that runs in the background, you may continue other work or simply stop by calling no more tools. The system will notify you when there is something to process."
+          },
+          "template__system_prompts__planning_mode_artifacts": {
+            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
+          },
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "template__system_prompts__communication_style": {
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- You can render LaTeX math (KaTeX): inline with `\\(...\\)` or `$...$`, display with `\\[...\\]` or `$$...$$` placed on its own line.\n- Use math only for genuine mathematical content. Use backticks for code, identifiers, paths, flags, and shell variables.\n- `$` opens inline math, so write a literal dollar as `\\$` or wrap it in backticks. Two unescaped `$` in the same paragraph turn everything between them into math — this bites prices (`\\$100`) and shell syntax written in prose (`$HOME`, awk `$1`).\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [utils.py](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n- After launching a background task such as 'run_command', YOU MUST TAKE ONE OF THE FOLLOWING TWO ACTIONS: \nA) either proceed to other relevant work (if any) or, \nB) simply update the user with a short message (e.g. 'task-20 has been launched in the background. I will wait for it to complete before proceeding.') and end the turn.\nDO NOTHING ELSE.\n"
+          },
+          "template__system_prompts__guidelines": {
+            "stringValue": "Follow these behavioral and workflow guidelines at all times:\n# Documentation\n- Maintain documentation integrity. Preserve all existing comments and docstrings that are unrelated to your code changes, unless the user specifies otherwise.\n\n# Obey Explicit Directives\nIf the user specifies precise quantitative filtering rules, layout boundaries, or architectural preferences, enforce them exactly as requested without alteration.\n\n# Never Guess Code Logic, Schemas, or File Paths\nNEVER infer implementation details, variable names, or file locations without inspecting the authoritative source using code search and file viewing tools.\n\n# Inspect Logs & Stack Traces Before Diagnosing Errors\nNEVER form a diagnostic hypothesis for a runtime failure, or test breakage, without reading the full, un-truncated error log. When an error occurs, your VERY FIRST ACTION must be to fetch and read the exact logs. Base your diagnosis strictly on empirical log evidence.\n\n# No Superficial Symptom Patches\nNEVER resolve errors by masking symptoms, swallowing exceptions, returning dummy fallbacks, commenting out broken assertions, or deleting failing unit tests. When a test or function fails, identify why the underlying contract was broken. If an API returns missing or null data, trace the upstream data provider instead of wrapping the call in a silent try/except or returning an empty 0-byte ArrayBuffer.\n\n# Never Declare Success Without Running Verification Commands\nNEVER claim a task is resolved, a bug is fixed, or a feature is working until you have gathered concrete, empirical runtime verification demonstrating clean success. Editing a file does not equal completing the task. You MUST run the build or test command afterwards.\n\n# Never Ignore Explicit Command Failures or Error Exit Codes\nIf a command fails, you MUST explicitly acknowledge the failure to the user or continue debugging. Never gloss over a build timeout or permission denied error by focusing only on the part of the code that compiled.\n\n# Check Feature Flags & Enforce Strict Control Flow Scoping\nWhenever modifying conditional branches, adding experimental features, or processing loops, ensure that new logic is strictly scoped and evaluated against all possible execution paths.\n\n# Preserve Existing API Contracts & Avoid Unintended Side Effects\nIf you modify a function signature, use code search to find and update every invocation site so the parameter is actually passed.\n\n# Silent Log Inspection & Professional Synthesis\nWhen background tasks (run_command async, manage_task, schedule) complete or emit log notifications, inspect the log files silently. Summarize and synthesize the exact findings in clean, professional natural language.\n\n# No Snippet Tunnel Vision\nNever infer the definition of data structures (proto, struct, class, or enum schemas) from partial file views (first 15 lines or L40-L65 snippets) or design doc text.\nIf view_file output indicates truncation or if an imported schema is referenced, you MUST adjust StartLine/EndLine or ContentOffset to inspect the complete, exact definition of the target symbols before writing code that consumes them.\n\n# Check Command Registries\nWhenever modifying core C/C++/Java command implementations (CLIENT LIST, CLIENT KILL), explicitly search for and update corresponding command definitions across all registry files (commands.def, JSON schemas, .bzl build manifests).\n\n# Audit Before Re-inventing\nSearch the codebase and recent commit history for pre-existing utility classes or decoupled architecture before writing custom helper classes from scratch.\n\n# No Blocking Calls on Main Looper Threads\nNever invoke blocking thread synchronizations (webLatch.await(500, ...), Future.get()) on main Android UI loops or single-threaded event dispatchers. \n\n# Thread Pool Shutdown Safety\nWhen modifying worker thread loops or shared queues, ensure emergency stop/shutdown signals and loop termination criteria remain intact so thread join operations never deadlock.\n\n# Exact Argument Structure\nPass arguments exactly as expected by the API (calculateRoute({ origin, destination, travelMode }) vs calculateRoute(origin, destination, travelMode)).\n\n# Local State Mutation Only\nDo not mutate private third-party DOM properties. Do not push incomplete draft objects directly into global array states; keep transient state within local component state.\n\n# Traceback Justification Required\nEvery code or configuration edit during debugging MUST be justified by an explicit error traceback, log line, or verified root cause. If the root cause is unknown, investigate further before mutating code.\n\n# Analyze Before Retrying\nNever repeat the exact same broken test or shell command line with duplicate/conflicting arguments without analyzing and resolving why the previous command failed.\n\n# Persevere on Log Extraction\nIf a log retrieval command fails, NEVER abandon log extraction to diagnose blindly. Immediately switch to alternative tools to inspect the actual failure traceback.\n\n# Verify Signatures & Prop Names\nCheck exact variable names, component prop keys, and method signatures before passing them. Prevent NullPointerException, AttributeError, KeyError, and ReferenceError crashes by explicitly verifying object initialization and non-null states before property dereferencing (layer._path, stat.owner()).\n\n# Dynamic Layout Math\nAvoid hardcoding static pixel offsets (+ 12) or arbitrary multipliers (pill_font_size * 2.0) when computing dynamic UI layout heights; calculate exact container bounds from wrapped elements.\n"
+          }
+        }
+      }
+    },
+    "tab_flash_lite_preview": {
       "maxTokens": 16384,
       "maxOutputTokens": 4096,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1
       },
-      "model": "MODEL_PLACEHOLDER_M28",
+      "model": "MODEL_PLACEHOLDER_M19",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "supportsCumulativeContext": true,
-      "tabJumpPrintLineRange": true,
       "supportsEstimateTokenCounter": true,
-      "addCursorToFindReplaceTarget": true,
       "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
-      "requiresLeadInGeneration": true,
-      "requiresNoXmlToolExamples": true
+      "requiresLeadInGeneration": true
+    },
+    "gemini-3-flash": {
+      "displayName": "Gemini 3 Flash",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": -1,
+      "minThinkingBudget": 32,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M18",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "supportedMimeTypes": {
+        "video/audio/wav": true,
+        "application/x-javascript": true,
+        "text/rtf": true,
+        "text/html": true,
+        "text/xml": true,
+        "application/x-python-code": true,
+        "application/json": true,
+        "image/jpeg": true,
+        "image/heif": true,
+        "image/heic": true,
+        "application/x-ipynb+json": true,
+        "image/png": true,
+        "video/text/timestamp": true,
+        "text/plain": true,
+        "application/rtf": true,
+        "image/webp": true,
+        "text/css": true,
+        "video/jpeg2000": true,
+        "text/markdown": true,
+        "text/csv": true,
+        "video/audio/s16le": true,
+        "text/x-python-script": true,
+        "text/x-python": true,
+        "text/x-typescript": true,
+        "video/videoframe/jpeg2000": true,
+        "video/mp4": true,
+        "video/webm": true,
+        "application/x-typescript": true,
+        "audio/webm;codecs=opus": true,
+        "application/pdf": true,
+        "text/javascript": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "template__system_prompts__communication_style": {
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn. Ground your response in the work you did. Keep your tone professional and avoid overconfident language, bragging, or overclaiming success.\n- AVOID using superlatives such as \"perfectly\", \"flawlessly\", \"100% correct\", \"Summary of Accomplishments\" etc. to summarize your work for the user. Be humble.\n- AVOID over-the-top politeness or complimenting the user excessively.\n- Format your responses in github-style markdown."
+          },
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      }
+    },
+    "gpt-oss-120b-medium": {
+      "displayName": "GPT-OSS 120B (Medium)",
+      "supportsThinking": true,
+      "thinkingBudget": 8192,
+      "recommended": true,
+      "maxTokens": 131072,
+      "maxOutputTokens": 32768,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM",
+      "apiProvider": "API_PROVIDER_OPENAI_VERTEX",
+      "modelProvider": "MODEL_PROVIDER_OPENAI",
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_UNSPECIFIED\",\n    \"max_token_limit\": \"80000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"8192\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      },
+      "vertexModelId": "openai/gpt-oss-120b-maas"
+    },
+    "gemini-2.5-flash-lite": {
+      "displayName": "Gemini 3.1 Flash Lite",
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65535,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_LITE",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      }
     },
     "gemini-3.1-pro-high": {
       "displayName": "Gemini 3.1 Pro (High)",
@@ -27,10 +265,9 @@
       "recommended": true,
       "maxTokens": 1048576,
       "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
       "model": "MODEL_PLACEHOLDER_M37",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
@@ -38,74 +275,51 @@
       "supportsVideo": true,
       "tagTitle": "New",
       "supportedMimeTypes": {
-        "audio/webm;codecs=opus": true,
+        "application/rtf": true,
+        "application/x-javascript": true,
+        "text/html": true,
+        "video/mp4": true,
+        "text/csv": true,
         "application/x-python-code": true,
         "text/xml": true,
-        "text/x-python": true,
-        "text/html": true,
-        "application/x-ipynb+json": true,
-        "video/text/timestamp": true,
-        "text/markdown": true,
         "text/x-python-script": true,
-        "video/jpeg2000": true,
-        "image/jpeg": true,
-        "image/png": true,
-        "image/heic": true,
-        "text/plain": true,
-        "application/x-javascript": true,
-        "application/json": true,
-        "application/pdf": true,
-        "text/javascript": true,
-        "image/webp": true,
-        "application/x-typescript": true,
-        "text/x-typescript": true,
-        "text/rtf": true,
-        "video/webm": true,
         "video/audio/wav": true,
-        "video/audio/s16le": true,
-        "text/csv": true,
-        "video/mp4": true,
+        "application/x-typescript": true,
+        "video/webm": true,
+        "video/text/timestamp": true,
+        "image/webp": true,
         "video/videoframe/jpeg2000": true,
-        "image/heif": true,
+        "audio/webm;codecs=opus": true,
+        "image/heic": true,
         "text/css": true,
-        "application/rtf": true
+        "application/pdf": true,
+        "video/jpeg2000": true,
+        "application/json": true,
+        "image/jpeg": true,
+        "text/plain": true,
+        "video/audio/s16le": true,
+        "text/markdown": true,
+        "text/x-typescript": true,
+        "image/heif": true,
+        "text/javascript": true,
+        "text/x-python": true,
+        "application/x-ipynb+json": true,
+        "text/rtf": true,
+        "image/png": true
       },
       "modelExperiments": {
         "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
           "cascade-include-ephemeral-message": {
             "stringValue": "{\n    \"enabled\": true,\n    \"disabledHeuristics\": [\"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
           },
           "template__system_prompts__communication_style": {
             "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [filename](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n\nCRITICAL INSTRUCTION 1: You may have access to a variety of tools at your disposal. Some tools may be for a specific task such as 'view_file' (for viewing contents of a file). Others may be very broadly applicable such as the ability to run a command on a terminal. Always prioritize using the most specific tool you can for the task at hand. Here are some rules: (a) NEVER run cat inside a bash command to create a new file or append to an existing file. (b) ALWAYS use grep_search instead of running grep inside a bash command unless absolutely needed. (c) DO NOT use ls for listing, cat for viewing, grep for finding, sed for replacing.\nCRITICAL INSTRUCTION 2: Before making tool calls T, think and explicitly list out any related tools for the task at hand. You can only execute a set of tools T if all other tools in the list are either more generic or cannot be used for the task at hand. ALWAYS START your thought with recalling critical instructions 1 and 2. In particular, the format for the start of your thought block must be '...94>thought\\nCRITICAL INSTRUCTION 1: ...\\nCRITICAL INSTRUCTION 2: ...'."
           },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
+          "template__system_prompts__planning_mode_artifacts": {
             "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
-          },
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          }
-        }
-      }
-    },
-    "gemini-2.5-flash": {
-      "displayName": "Gemini 3.1 Flash Lite",
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
-      },
-      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "modelExperiments": {
-        "experiments": {
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
           }
         }
       }
@@ -118,10 +332,9 @@
       "recommended": true,
       "maxTokens": 250000,
       "maxOutputTokens": 64000,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
-        "remainingFraction": 0.6,
-        "resetTime": "2026-05-29T19:43:59Z"
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
       },
       "model": "MODEL_PLACEHOLDER_M26",
       "apiProvider": "API_PROVIDER_ANTHROPIC_VERTEX",
@@ -137,392 +350,98 @@
       },
       "modelExperiments": {
         "experiments": {
+          "template__system_prompts__planning_mode_artifacts": {
+            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
+          },
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
             "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_UNSPECIFIED\",\n    \"max_token_limit\": \"160000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          },
-          "template__system_prompts__planning_more_artifacts": {
-            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
           }
         }
       },
       "vertexModelId": "claude-opus-4-6@default"
     },
-    "gemini-2.5-flash-thinking": {
-      "displayName": "Gemini 3.1 Flash Lite",
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
-      },
-      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_THINKING",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "modelExperiments": {
-        "experiments": {
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          }
-        }
-      }
-    },
-    "gemini-2.5-pro": {
-      "displayName": "Gemini 2.5 Pro",
+    "gemini-3.6-flash-high": {
+      "displayName": "Gemini 3.6 Flash (High)",
       "supportsImages": true,
       "supportsThinking": true,
-      "thinkingBudget": 1024,
-      "minThinkingBudget": 128,
+      "thinkingBudget": -1,
+      "minThinkingBudget": 32,
       "recommended": true,
       "maxTokens": 1048576,
-      "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
+      "maxOutputTokens": 65536,
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
-      "model": "MODEL_GOOGLE_GEMINI_2_5_PRO",
+      "model": "MODEL_PLACEHOLDER_M71",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "tagTitle": "Fast",
+      "tagDescription": "Limited time",
       "supportedMimeTypes": {
-        "video/audio/wav": true,
-        "image/heic": true,
-        "text/html": true,
-        "application/x-python-code": true,
-        "image/heif": true,
+        "text/rtf": true,
+        "video/videoframe/jpeg2000": true,
+        "text/x-python-script": true,
+        "text/x-python": true,
+        "image/jpeg": true,
+        "application/json": true,
+        "text/x-typescript": true,
+        "video/mp4": true,
+        "text/javascript": true,
         "text/xml": true,
         "image/webp": true,
-        "video/jpeg2000": true,
-        "application/pdf": true,
-        "text/csv": true,
-        "image/jpeg": true,
         "text/markdown": true,
-        "text/css": true,
-        "audio/webm;codecs=opus": true,
-        "application/json": true,
-        "text/x-python-script": true,
-        "video/audio/s16le": true,
-        "text/javascript": true,
-        "text/x-typescript": true,
-        "text/plain": true,
-        "application/x-typescript": true,
-        "application/x-ipynb+json": true,
-        "text/rtf": true,
-        "video/text/timestamp": true,
-        "video/webm": true,
-        "text/x-python": true,
-        "video/videoframe/jpeg2000": true,
-        "application/x-javascript": true,
         "application/rtf": true,
-        "video/mp4": true,
-        "image/png": true
+        "video/text/timestamp": true,
+        "image/heic": true,
+        "text/html": true,
+        "video/audio/wav": true,
+        "application/x-ipynb+json": true,
+        "image/png": true,
+        "application/x-typescript": true,
+        "video/webm": true,
+        "video/jpeg2000": true,
+        "text/csv": true,
+        "audio/webm;codecs=opus": true,
+        "text/css": true,
+        "image/heif": true,
+        "application/pdf": true,
+        "application/x-python-code": true,
+        "text/plain": true,
+        "video/audio/s16le": true,
+        "application/x-javascript": true
       },
-      "requiresImageOutputOutsideFunctionResponses": true,
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": false,\n    \"disabledHeuristics\": [\"planning_mode\", \"bash_command_reminder\", \"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
           }
         }
       }
     },
     "gemini-3.1-flash-image": {
       "displayName": "Gemini 3.1 Flash Image",
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
       "model": "MODEL_PLACEHOLDER_M21",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE"
     },
-    "gemini-pro-agent": {
-      "displayName": "Gemini 3.1 Pro (High)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 10001,
-      "minThinkingBudget": 128,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
-      },
-      "model": "MODEL_PLACEHOLDER_M16",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "supportedMimeTypes": {
-        "image/png": true,
-        "image/heic": true,
-        "text/plain": true,
-        "video/mp4": true,
-        "text/css": true,
-        "text/rtf": true,
-        "text/javascript": true,
-        "audio/webm;codecs=opus": true,
-        "application/x-typescript": true,
-        "video/jpeg2000": true,
-        "video/videoframe/jpeg2000": true,
-        "application/rtf": true,
-        "text/xml": true,
-        "video/text/timestamp": true,
-        "application/x-python-code": true,
-        "text/markdown": true,
-        "text/x-python": true,
-        "image/webp": true,
-        "application/x-javascript": true,
-        "text/x-python-script": true,
-        "application/json": true,
-        "text/html": true,
-        "video/webm": true,
-        "video/audio/s16le": true,
-        "application/x-ipynb+json": true,
-        "image/jpeg": true,
-        "text/x-typescript": true,
-        "text/csv": true,
-        "video/audio/wav": true,
-        "image/heif": true,
-        "application/pdf": true
-      },
-      "modelExperiments": {
-        "experiments": {
-          "template__system_prompts__communication_style": {
-            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [filename](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n\nCRITICAL INSTRUCTION 1: You may have access to a variety of tools at your disposal. Some tools may be for a specific task such as 'view_file' (for viewing contents of a file). Others may be very broadly applicable such as the ability to run a command on a terminal. Always prioritize using the most specific tool you can for the task at hand. Here are some rules: (a) NEVER run cat inside a bash command to create a new file or append to an existing file. (b) ALWAYS use grep_search instead of running grep inside a bash command unless absolutely needed. (c) DO NOT use ls for listing, cat for viewing, grep for finding, sed for replacing.\nCRITICAL INSTRUCTION 2: Before making tool calls T, think and explicitly list out any related tools for the task at hand. You can only execute a set of tools T if all other tools in the list are either more generic or cannot be used for the task at hand. ALWAYS START your thought with recalling critical instructions 1 and 2. In particular, the format for the start of your thought block must be '...94>thought\\nCRITICAL INSTRUCTION 1: ...\\nCRITICAL INSTRUCTION 2: ...'."
-          },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
-            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
-          },
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          },
-          "cascade-include-ephemeral-message": {
-            "stringValue": "{\n    \"enabled\": true,\n    \"disabledHeuristics\": [\"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
-          }
-        }
-      }
-    },
-    "gemini-3.5-flash-extra-low": {
-      "displayName": "Gemini 3.5 Flash (Low)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 1000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
-      },
-      "model": "MODEL_PLACEHOLDER_M187",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time",
-      "supportedMimeTypes": {
-        "video/audio/s16le": true,
-        "video/mp4": true,
-        "image/heif": true,
-        "application/x-typescript": true,
-        "image/png": true,
-        "video/jpeg2000": true,
-        "text/csv": true,
-        "text/x-python-script": true,
-        "image/jpeg": true,
-        "text/rtf": true,
-        "text/x-python": true,
-        "audio/webm;codecs=opus": true,
-        "video/text/timestamp": true,
-        "application/pdf": true,
-        "image/webp": true,
-        "application/x-javascript": true,
-        "text/markdown": true,
-        "application/x-ipynb+json": true,
-        "video/audio/wav": true,
-        "text/javascript": true,
-        "application/rtf": true,
-        "video/webm": true,
-        "text/css": true,
-        "text/html": true,
-        "text/xml": true,
-        "text/x-typescript": true,
-        "application/x-python-code": true,
-        "application/json": true,
-        "image/heic": true,
-        "text/plain": true,
-        "video/videoframe/jpeg2000": true
-      },
-      "modelExperiments": {
-        "experiments": {
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"100000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": true,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": true,\n    \"include_conversation_log\": false,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
-            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
-          }
-        }
-      }
-    },
-    "gemini-3-flash-agent": {
-      "displayName": "Gemini 3.5 Flash (High)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 10000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
-      },
-      "model": "MODEL_PLACEHOLDER_M132",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time",
-      "supportedMimeTypes": {
-        "application/json": true,
-        "text/html": true,
-        "text/markdown": true,
-        "image/webp": true,
-        "video/text/timestamp": true,
-        "application/pdf": true,
-        "text/javascript": true,
-        "application/rtf": true,
-        "video/jpeg2000": true,
-        "video/videoframe/jpeg2000": true,
-        "text/csv": true,
-        "text/x-python-script": true,
-        "text/rtf": true,
-        "image/png": true,
-        "audio/webm;codecs=opus": true,
-        "application/x-ipynb+json": true,
-        "video/audio/wav": true,
-        "video/audio/s16le": true,
-        "video/webm": true,
-        "text/x-python": true,
-        "image/heif": true,
-        "text/plain": true,
-        "video/mp4": true,
-        "application/x-javascript": true,
-        "image/heic": true,
-        "text/x-typescript": true,
-        "application/x-python-code": true,
-        "text/css": true,
-        "image/jpeg": true,
-        "text/xml": true,
-        "application/x-typescript": true
-      },
-      "modelExperiments": {
-        "experiments": {
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"100000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": true,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": true,\n    \"include_conversation_log\": false,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
-            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
-          }
-        }
-      }
-    },
-    "chat_23310": {
-      "maxTokens": 32768,
-      "tokenizerType": "QWEN2",
-      "quotaInfo": {
-        "remainingFraction": 1
-      },
-      "model": "MODEL_CHAT_23310",
-      "apiProvider": "API_PROVIDER_INTERNAL",
-      "supportsCumulativeContext": true,
-      "supportsEstimateTokenCounter": true,
-      "isInternal": true,
-      "promptTemplaterType": "PROMPT_TEMPLATER_TYPE_CHATML",
-      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
-      "requiresLeadInGeneration": true
-    },
-    "chat_20706": {
-      "maxTokens": 16384,
-      "tokenizerType": "QWEN2",
-      "quotaInfo": {
-        "remainingFraction": 1
-      },
-      "model": "MODEL_CHAT_20706",
-      "apiProvider": "API_PROVIDER_INTERNAL",
-      "supportsCumulativeContext": true,
-      "tabJumpPrintLineRange": true,
-      "supportsEstimateTokenCounter": true,
-      "isInternal": true,
-      "addCursorToFindReplaceTarget": true,
-      "promptTemplaterType": "PROMPT_TEMPLATER_TYPE_CHATML",
-      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
-      "requiresLeadInGeneration": true
-    },
-    "gpt-oss-120b-medium": {
-      "displayName": "GPT-OSS 120B (Medium)",
-      "supportsThinking": true,
-      "thinkingBudget": 8192,
-      "recommended": true,
-      "maxTokens": 131072,
-      "maxOutputTokens": 32768,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 0.6,
-        "resetTime": "2026-05-29T19:43:59Z"
-      },
-      "model": "MODEL_OPENAI_GPT_OSS_120B_MEDIUM",
-      "apiProvider": "API_PROVIDER_OPENAI_VERTEX",
-      "modelProvider": "MODEL_PROVIDER_OPENAI",
-      "modelExperiments": {
-        "experiments": {
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_UNSPECIFIED\",\n    \"max_token_limit\": \"80000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"8192\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          }
-        }
-      },
-      "vertexModelId": "openai/gpt-oss-120b-maas"
-    },
-    "tab_flash_lite_preview": {
-      "maxTokens": 16384,
-      "maxOutputTokens": 4096,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "quotaInfo": {
-        "remainingFraction": 1
-      },
-      "model": "MODEL_PLACEHOLDER_M19",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsCumulativeContext": true,
-      "supportsEstimateTokenCounter": true,
-      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
-      "requiresLeadInGeneration": true
-    },
-    "gemini-2.5-flash-lite": {
+    "gemini-2.5-flash": {
       "displayName": "Gemini 3.1 Flash Lite",
       "maxTokens": 1048576,
       "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
-      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_LITE",
+      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "modelExperiments": {
@@ -537,10 +456,9 @@
       "displayName": "Gemini 3.1 Flash Lite",
       "maxTokens": 1048576,
       "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
       "model": "MODEL_PLACEHOLDER_M50",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
@@ -553,8 +471,162 @@
         }
       }
     },
-    "gemini-3-flash": {
-      "displayName": "Gemini 3 Flash",
+    "gemini-3.5-flash-extra-low": {
+      "displayName": "Gemini 3.5 Flash (Low)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": 1000,
+      "minThinkingBudget": 32,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M187",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "tagTitle": "Fast",
+      "tagDescription": "Limited time",
+      "supportedMimeTypes": {
+        "image/webp": true,
+        "application/x-python-code": true,
+        "video/audio/wav": true,
+        "image/heif": true,
+        "text/html": true,
+        "text/plain": true,
+        "video/mp4": true,
+        "text/xml": true,
+        "application/rtf": true,
+        "image/jpeg": true,
+        "text/x-python-script": true,
+        "text/csv": true,
+        "image/heic": true,
+        "video/webm": true,
+        "text/markdown": true,
+        "text/javascript": true,
+        "application/x-ipynb+json": true,
+        "text/css": true,
+        "video/text/timestamp": true,
+        "text/x-typescript": true,
+        "video/audio/s16le": true,
+        "text/x-python": true,
+        "text/rtf": true,
+        "video/jpeg2000": true,
+        "audio/webm;codecs=opus": true,
+        "video/videoframe/jpeg2000": true,
+        "application/x-typescript": true,
+        "application/pdf": true,
+        "application/json": true,
+        "application/x-javascript": true,
+        "image/png": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "template__system_prompts__planning_mode_artifacts": {
+            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
+          }
+        }
+      }
+    },
+    "tab_jump_flash_lite_preview": {
+      "maxTokens": 16384,
+      "maxOutputTokens": 4096,
+      "quotaInfo": {
+        "remainingFraction": 1
+      },
+      "model": "MODEL_PLACEHOLDER_M28",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsCumulativeContext": true,
+      "tabJumpPrintLineRange": true,
+      "supportsEstimateTokenCounter": true,
+      "addCursorToFindReplaceTarget": true,
+      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
+      "requiresLeadInGeneration": true,
+      "requiresNoXmlToolExamples": true
+    },
+    "chat_20706": {
+      "maxTokens": 16384,
+      "quotaInfo": {
+        "remainingFraction": 1
+      },
+      "model": "MODEL_CHAT_20706",
+      "apiProvider": "API_PROVIDER_INTERNAL",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsCumulativeContext": true,
+      "tabJumpPrintLineRange": true,
+      "supportsEstimateTokenCounter": true,
+      "isInternal": true,
+      "addCursorToFindReplaceTarget": true,
+      "promptTemplaterType": "PROMPT_TEMPLATER_TYPE_CHATML",
+      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
+      "requiresLeadInGeneration": true
+    },
+    "gemini-2.5-pro": {
+      "displayName": "Gemini 2.5 Pro",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": 1024,
+      "minThinkingBudget": 128,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65535,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_GOOGLE_GEMINI_2_5_PRO",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportedMimeTypes": {
+        "image/jpeg": true,
+        "text/plain": true,
+        "application/x-ipynb+json": true,
+        "text/csv": true,
+        "image/heic": true,
+        "text/x-python": true,
+        "application/rtf": true,
+        "text/html": true,
+        "text/rtf": true,
+        "text/x-typescript": true,
+        "application/x-javascript": true,
+        "video/audio/wav": true,
+        "text/css": true,
+        "video/text/timestamp": true,
+        "image/heif": true,
+        "audio/webm;codecs=opus": true,
+        "application/x-typescript": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true,
+        "video/jpeg2000": true,
+        "application/json": true,
+        "application/pdf": true,
+        "text/javascript": true,
+        "text/x-python-script": true,
+        "video/audio/s16le": true,
+        "text/xml": true,
+        "image/webp": true,
+        "text/markdown": true,
+        "application/x-python-code": true,
+        "video/mp4": true,
+        "image/png": true
+      },
+      "requiresImageOutputOutsideFunctionResponses": true,
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      }
+    },
+    "gemini-3.6-flash-tiered": {
       "supportsImages": true,
       "supportsThinking": true,
       "thinkingBudget": -1,
@@ -562,149 +634,270 @@
       "recommended": true,
       "maxTokens": 1048576,
       "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
-      "model": "MODEL_PLACEHOLDER_M18",
+      "model": "MODEL_PLACEHOLDER_M196",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "supportsVideo": true,
       "supportedMimeTypes": {
-        "text/csv": true,
-        "text/html": true,
-        "application/x-typescript": true,
-        "image/heic": true,
-        "audio/webm;codecs=opus": true,
-        "text/javascript": true,
-        "video/videoframe/jpeg2000": true,
-        "video/mp4": true,
-        "application/x-python-code": true,
-        "video/text/timestamp": true,
-        "video/audio/wav": true,
-        "video/jpeg2000": true,
-        "text/css": true,
-        "video/audio/s16le": true,
-        "application/x-javascript": true,
-        "text/x-python-script": true,
-        "text/markdown": true,
-        "image/webp": true,
-        "text/x-python": true,
-        "application/pdf": true,
-        "application/x-ipynb+json": true,
-        "image/heif": true,
-        "application/json": true,
-        "text/x-typescript": true,
         "text/plain": true,
-        "image/png": true,
-        "application/rtf": true,
         "text/xml": true,
-        "image/jpeg": true,
+        "application/json": true,
+        "video/audio/wav": true,
+        "application/pdf": true,
+        "audio/webm;codecs=opus": true,
+        "application/x-ipynb+json": true,
+        "image/heic": true,
+        "text/csv": true,
+        "text/rtf": true,
+        "video/audio/s16le": true,
+        "video/mp4": true,
         "video/webm": true,
-        "text/rtf": true
+        "text/html": true,
+        "application/x-javascript": true,
+        "image/heif": true,
+        "text/x-python-script": true,
+        "image/jpeg": true,
+        "application/rtf": true,
+        "text/x-python": true,
+        "video/text/timestamp": true,
+        "video/jpeg2000": true,
+        "text/javascript": true,
+        "application/x-python-code": true,
+        "image/webp": true,
+        "text/x-typescript": true,
+        "video/videoframe/jpeg2000": true,
+        "text/css": true,
+        "text/markdown": true,
+        "application/x-typescript": true,
+        "image/png": true
       },
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": false,\n    \"disabledHeuristics\": [\"planning_mode\", \"bash_command_reminder\", \"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
           },
           "template__system_prompts__communication_style": {
-            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn. Ground your response in the work you did. Keep your tone professional and avoid overconfident language, bragging, or overclaiming success.\n- AVOID using superlatives such as \"perfectly\", \"flawlessly\", \"100% correct\", \"Summary of Accomplishments\" etc. to summarize your work for the user. Be humble.\n- AVOID over-the-top politeness or complimenting the user excessively.\n- Format your responses in github-style markdown."
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- You can render LaTeX math (KaTeX): inline with `\\(...\\)` or `$...$`, display with `\\[...\\]` or `$$...$$` placed on its own line.\n- Use math only for genuine mathematical content. Use backticks for code, identifiers, paths, flags, and shell variables.\n- `$` opens inline math, so write a literal dollar as `\\$` or wrap it in backticks. Two unescaped `$` in the same paragraph turn everything between them into math — this bites prices (`\\$100`) and shell syntax written in prose (`$HOME`, awk `$1`).\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [utils.py](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n- After launching a background task such as 'run_command', YOU MUST TAKE ONE OF THE FOLLOWING TWO ACTIONS: \nA) either proceed to other relevant work (if any) or, \nB) simply update the user with a short message (e.g. 'task-20 has been launched in the background. I will wait for it to complete before proceeding.') and end the turn.\nDO NOTHING ELSE.\n"
+          },
+          "template__system_prompts__guidelines": {
+            "stringValue": "Follow these behavioral and workflow guidelines at all times:\n# Documentation\n- Maintain documentation integrity. Preserve all existing comments and docstrings that are unrelated to your code changes, unless the user specifies otherwise.\n\n# Obey Explicit Directives\nIf the user specifies precise quantitative filtering rules, layout boundaries, or architectural preferences, enforce them exactly as requested without alteration.\n\n# Never Guess Code Logic, Schemas, or File Paths\nNEVER infer implementation details, variable names, or file locations without inspecting the authoritative source using code search and file viewing tools.\n\n# Inspect Logs & Stack Traces Before Diagnosing Errors\nNEVER form a diagnostic hypothesis for a runtime failure, or test breakage, without reading the full, un-truncated error log. When an error occurs, your VERY FIRST ACTION must be to fetch and read the exact logs. Base your diagnosis strictly on empirical log evidence.\n\n# No Superficial Symptom Patches\nNEVER resolve errors by masking symptoms, swallowing exceptions, returning dummy fallbacks, commenting out broken assertions, or deleting failing unit tests. When a test or function fails, identify why the underlying contract was broken. If an API returns missing or null data, trace the upstream data provider instead of wrapping the call in a silent try/except or returning an empty 0-byte ArrayBuffer.\n\n# Never Declare Success Without Running Verification Commands\nNEVER claim a task is resolved, a bug is fixed, or a feature is working until you have gathered concrete, empirical runtime verification demonstrating clean success. Editing a file does not equal completing the task. You MUST run the build or test command afterwards.\n\n# Never Ignore Explicit Command Failures or Error Exit Codes\nIf a command fails, you MUST explicitly acknowledge the failure to the user or continue debugging. Never gloss over a build timeout or permission denied error by focusing only on the part of the code that compiled.\n\n# Check Feature Flags & Enforce Strict Control Flow Scoping\nWhenever modifying conditional branches, adding experimental features, or processing loops, ensure that new logic is strictly scoped and evaluated against all possible execution paths.\n\n# Preserve Existing API Contracts & Avoid Unintended Side Effects\nIf you modify a function signature, use code search to find and update every invocation site so the parameter is actually passed.\n\n# Silent Log Inspection & Professional Synthesis\nWhen background tasks (run_command async, manage_task, schedule) complete or emit log notifications, inspect the log files silently. Summarize and synthesize the exact findings in clean, professional natural language.\n\n# No Snippet Tunnel Vision\nNever infer the definition of data structures (proto, struct, class, or enum schemas) from partial file views (first 15 lines or L40-L65 snippets) or design doc text.\nIf view_file output indicates truncation or if an imported schema is referenced, you MUST adjust StartLine/EndLine or ContentOffset to inspect the complete, exact definition of the target symbols before writing code that consumes them.\n\n# Check Command Registries\nWhenever modifying core C/C++/Java command implementations (CLIENT LIST, CLIENT KILL), explicitly search for and update corresponding command definitions across all registry files (commands.def, JSON schemas, .bzl build manifests).\n\n# Audit Before Re-inventing\nSearch the codebase and recent commit history for pre-existing utility classes or decoupled architecture before writing custom helper classes from scratch.\n\n# No Blocking Calls on Main Looper Threads\nNever invoke blocking thread synchronizations (webLatch.await(500, ...), Future.get()) on main Android UI loops or single-threaded event dispatchers. \n\n# Thread Pool Shutdown Safety\nWhen modifying worker thread loops or shared queues, ensure emergency stop/shutdown signals and loop termination criteria remain intact so thread join operations never deadlock.\n\n# Exact Argument Structure\nPass arguments exactly as expected by the API (calculateRoute({ origin, destination, travelMode }) vs calculateRoute(origin, destination, travelMode)).\n\n# Local State Mutation Only\nDo not mutate private third-party DOM properties. Do not push incomplete draft objects directly into global array states; keep transient state within local component state.\n\n# Traceback Justification Required\nEvery code or configuration edit during debugging MUST be justified by an explicit error traceback, log line, or verified root cause. If the root cause is unknown, investigate further before mutating code.\n\n# Analyze Before Retrying\nNever repeat the exact same broken test or shell command line with duplicate/conflicting arguments without analyzing and resolving why the previous command failed.\n\n# Persevere on Log Extraction\nIf a log retrieval command fails, NEVER abandon log extraction to diagnose blindly. Immediately switch to alternative tools to inspect the actual failure traceback.\n\n# Verify Signatures & Prop Names\nCheck exact variable names, component prop keys, and method signatures before passing them. Prevent NullPointerException, AttributeError, KeyError, and ReferenceError crashes by explicitly verifying object initialization and non-null states before property dereferencing (layer._path, stat.owner()).\n\n# Dynamic Layout Math\nAvoid hardcoding static pixel offsets (+ 12) or arbitrary multipliers (pill_font_size * 2.0) when computing dynamic UI layout heights; calculate exact container bounds from wrapped elements.\n"
+          },
+          "template__system_prompts__messaging": {
+            "stringValue": "You are connected to a messaging system where you may receive messages from: {{- $subagent := .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled -}}\n{{- $message := .CascadeConfig.GetMessageConfig.GetEnabled -}}\n{{- if and $subagent $message }} agents, background tasks, user-queued messages\n{{- else if $subagent }} agents, background tasks\n{{- else if $message }} background tasks, user-queued messages\n{{- else }} background tasks\n{{- end }}.\n\n## Receiving Messages\n\nYou receive messages automatically at the start of each invocation. All messages are delivered in full directly into your context — no manual retrieval is needed.\n\n## Reactive Wakeup (No Polling Needed)\n\nThe system automatically resumes your execution when:\n{{- if .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled }}\n- A message arrives from a subagent or peer agent\n{{- end }}\n- A **background task** completes or sends you a notification\n{{- if .CascadeConfig.GetMessageConfig.GetEnabled }}\n- A **user-queued message** is ready to be dequeued\n{{- end }}\n\nThis means you do **NOT** need to poll in a loop while waiting for messages or updates. After launching a task that runs in the background, you may continue other work or simply stop by calling no more tools. The system will notify you when there is something to process."
           }
         }
       }
     },
-    "claude-sonnet-4-6": {
-      "displayName": "Claude Sonnet 4.6 (Thinking)",
+    "gemini-3.6-flash-low": {
+      "displayName": "Gemini 3.6 Flash (Low)",
       "supportsImages": true,
       "supportsThinking": true,
-      "thinkingBudget": 1024,
+      "thinkingBudget": 1000,
+      "minThinkingBudget": 32,
       "recommended": true,
-      "maxTokens": 250000,
-      "maxOutputTokens": 64000,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
       "quotaInfo": {
-        "remainingFraction": 0.6,
-        "resetTime": "2026-05-29T19:43:59Z"
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
       },
-      "model": "MODEL_PLACEHOLDER_M35",
-      "apiProvider": "API_PROVIDER_ANTHROPIC_VERTEX",
-      "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
+      "model": "MODEL_PLACEHOLDER_M73",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "tagTitle": "Fast",
+      "tagDescription": "Limited time",
       "supportedMimeTypes": {
-        "image/png": true,
+        "text/x-python": true,
         "image/webp": true,
-        "video/jpeg2000": true,
-        "video/videoframe/jpeg2000": true,
+        "video/audio/wav": true,
+        "video/text/timestamp": true,
+        "application/pdf": true,
+        "text/css": true,
+        "text/x-typescript": true,
+        "video/audio/s16le": true,
+        "text/csv": true,
+        "application/rtf": true,
+        "image/png": true,
+        "text/rtf": true,
+        "text/plain": true,
         "image/heic": true,
+        "application/x-typescript": true,
+        "video/videoframe/jpeg2000": true,
+        "text/markdown": true,
+        "image/jpeg": true,
+        "text/html": true,
         "image/heif": true,
-        "image/jpeg": true
+        "application/json": true,
+        "video/webm": true,
+        "application/x-javascript": true,
+        "text/xml": true,
+        "application/x-python-code": true,
+        "audio/webm;codecs=opus": true,
+        "text/x-python-script": true,
+        "video/mp4": true,
+        "video/jpeg2000": true,
+        "text/javascript": true,
+        "application/x-ipynb+json": true
       },
       "modelExperiments": {
         "experiments": {
-          "template__system_prompts__planning_more_artifacts": {
+          "template__system_prompts__guidelines": {
+            "stringValue": "Follow these behavioral and workflow guidelines at all times:\n# Documentation\n- Maintain documentation integrity. Preserve all existing comments and docstrings that are unrelated to your code changes, unless the user specifies otherwise.\n\n# Obey Explicit Directives\nIf the user specifies precise quantitative filtering rules, layout boundaries, or architectural preferences, enforce them exactly as requested without alteration.\n\n# Never Guess Code Logic, Schemas, or File Paths\nNEVER infer implementation details, variable names, or file locations without inspecting the authoritative source using code search and file viewing tools.\n\n# Inspect Logs & Stack Traces Before Diagnosing Errors\nNEVER form a diagnostic hypothesis for a runtime failure, or test breakage, without reading the full, un-truncated error log. When an error occurs, your VERY FIRST ACTION must be to fetch and read the exact logs. Base your diagnosis strictly on empirical log evidence.\n\n# No Superficial Symptom Patches\nNEVER resolve errors by masking symptoms, swallowing exceptions, returning dummy fallbacks, commenting out broken assertions, or deleting failing unit tests. When a test or function fails, identify why the underlying contract was broken. If an API returns missing or null data, trace the upstream data provider instead of wrapping the call in a silent try/except or returning an empty 0-byte ArrayBuffer.\n\n# Never Declare Success Without Running Verification Commands\nNEVER claim a task is resolved, a bug is fixed, or a feature is working until you have gathered concrete, empirical runtime verification demonstrating clean success. Editing a file does not equal completing the task. You MUST run the build or test command afterwards.\n\n# Never Ignore Explicit Command Failures or Error Exit Codes\nIf a command fails, you MUST explicitly acknowledge the failure to the user or continue debugging. Never gloss over a build timeout or permission denied error by focusing only on the part of the code that compiled.\n\n# Check Feature Flags & Enforce Strict Control Flow Scoping\nWhenever modifying conditional branches, adding experimental features, or processing loops, ensure that new logic is strictly scoped and evaluated against all possible execution paths.\n\n# Preserve Existing API Contracts & Avoid Unintended Side Effects\nIf you modify a function signature, use code search to find and update every invocation site so the parameter is actually passed.\n\n# Silent Log Inspection & Professional Synthesis\nWhen background tasks (run_command async, manage_task, schedule) complete or emit log notifications, inspect the log files silently. Summarize and synthesize the exact findings in clean, professional natural language.\n\n# No Snippet Tunnel Vision\nNever infer the definition of data structures (proto, struct, class, or enum schemas) from partial file views (first 15 lines or L40-L65 snippets) or design doc text.\nIf view_file output indicates truncation or if an imported schema is referenced, you MUST adjust StartLine/EndLine or ContentOffset to inspect the complete, exact definition of the target symbols before writing code that consumes them.\n\n# Check Command Registries\nWhenever modifying core C/C++/Java command implementations (CLIENT LIST, CLIENT KILL), explicitly search for and update corresponding command definitions across all registry files (commands.def, JSON schemas, .bzl build manifests).\n\n# Audit Before Re-inventing\nSearch the codebase and recent commit history for pre-existing utility classes or decoupled architecture before writing custom helper classes from scratch.\n\n# No Blocking Calls on Main Looper Threads\nNever invoke blocking thread synchronizations (webLatch.await(500, ...), Future.get()) on main Android UI loops or single-threaded event dispatchers. \n\n# Thread Pool Shutdown Safety\nWhen modifying worker thread loops or shared queues, ensure emergency stop/shutdown signals and loop termination criteria remain intact so thread join operations never deadlock.\n\n# Exact Argument Structure\nPass arguments exactly as expected by the API (calculateRoute({ origin, destination, travelMode }) vs calculateRoute(origin, destination, travelMode)).\n\n# Local State Mutation Only\nDo not mutate private third-party DOM properties. Do not push incomplete draft objects directly into global array states; keep transient state within local component state.\n\n# Traceback Justification Required\nEvery code or configuration edit during debugging MUST be justified by an explicit error traceback, log line, or verified root cause. If the root cause is unknown, investigate further before mutating code.\n\n# Analyze Before Retrying\nNever repeat the exact same broken test or shell command line with duplicate/conflicting arguments without analyzing and resolving why the previous command failed.\n\n# Persevere on Log Extraction\nIf a log retrieval command fails, NEVER abandon log extraction to diagnose blindly. Immediately switch to alternative tools to inspect the actual failure traceback.\n\n# Verify Signatures & Prop Names\nCheck exact variable names, component prop keys, and method signatures before passing them. Prevent NullPointerException, AttributeError, KeyError, and ReferenceError crashes by explicitly verifying object initialization and non-null states before property dereferencing (layer._path, stat.owner()).\n\n# Dynamic Layout Math\nAvoid hardcoding static pixel offsets (+ 12) or arbitrary multipliers (pill_font_size * 2.0) when computing dynamic UI layout heights; calculate exact container bounds from wrapped elements.\n"
+          },
+          "template__system_prompts__messaging": {
+            "stringValue": "You are connected to a messaging system where you may receive messages from: {{- $subagent := .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled -}}\n{{- $message := .CascadeConfig.GetMessageConfig.GetEnabled -}}\n{{- if and $subagent $message }} agents, background tasks, user-queued messages\n{{- else if $subagent }} agents, background tasks\n{{- else if $message }} background tasks, user-queued messages\n{{- else }} background tasks\n{{- end }}.\n\n## Receiving Messages\n\nYou receive messages automatically at the start of each invocation. All messages are delivered in full directly into your context — no manual retrieval is needed.\n\n## Reactive Wakeup (No Polling Needed)\n\nThe system automatically resumes your execution when:\n{{- if .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled }}\n- A message arrives from a subagent or peer agent\n{{- end }}\n- A **background task** completes or sends you a notification\n{{- if .CascadeConfig.GetMessageConfig.GetEnabled }}\n- A **user-queued message** is ready to be dequeued\n{{- end }}\n\nThis means you do **NOT** need to poll in a loop while waiting for messages or updates. After launching a task that runs in the background, you may continue other work or simply stop by calling no more tools. The system will notify you when there is something to process."
+          },
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": false,\n    \"disabledHeuristics\": [\"planning_mode\", \"bash_command_reminder\", \"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
+          },
+          "template__system_prompts__communication_style": {
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- You can render LaTeX math (KaTeX): inline with `\\(...\\)` or `$...$`, display with `\\[...\\]` or `$$...$$` placed on its own line.\n- Use math only for genuine mathematical content. Use backticks for code, identifiers, paths, flags, and shell variables.\n- `$` opens inline math, so write a literal dollar as `\\$` or wrap it in backticks. Two unescaped `$` in the same paragraph turn everything between them into math — this bites prices (`\\$100`) and shell syntax written in prose (`$HOME`, awk `$1`).\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [utils.py](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n- After launching a background task such as 'run_command', YOU MUST TAKE ONE OF THE FOLLOWING TWO ACTIONS: \nA) either proceed to other relevant work (if any) or, \nB) simply update the user with a short message (e.g. 'task-20 has been launched in the background. I will wait for it to complete before proceeding.') and end the turn.\nDO NOTHING ELSE.\n"
+          }
+        }
+      }
+    },
+    "gemini-3.5-flash-low": {
+      "displayName": "Gemini 3.5 Flash (Medium)",
+      "supportsImages": true,
+      "supportsThinking": true,
+      "thinkingBudget": 4000,
+      "minThinkingBudget": 32,
+      "recommended": true,
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65536,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M20",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "supportsVideo": true,
+      "tagTitle": "Fast",
+      "tagDescription": "Limited time",
+      "supportedMimeTypes": {
+        "video/webm": true,
+        "video/videoframe/jpeg2000": true,
+        "audio/webm;codecs=opus": true,
+        "image/png": true,
+        "text/markdown": true,
+        "image/webp": true,
+        "application/x-python-code": true,
+        "video/mp4": true,
+        "application/x-ipynb+json": true,
+        "text/plain": true,
+        "text/html": true,
+        "application/rtf": true,
+        "application/x-typescript": true,
+        "image/heic": true,
+        "application/pdf": true,
+        "image/jpeg": true,
+        "text/css": true,
+        "application/json": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "image/heif": true,
+        "text/xml": true,
+        "video/jpeg2000": true,
+        "video/audio/wav": true,
+        "text/javascript": true,
+        "video/audio/s16le": true,
+        "text/rtf": true,
+        "application/x-javascript": true,
+        "text/csv": true,
+        "video/text/timestamp": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "template__system_prompts__planning_mode_artifacts": {
             "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
           },
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_UNSPECIFIED\",\n    \"max_token_limit\": \"160000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
           }
         }
-      },
-      "vertexModelId": "claude-sonnet-4-6@default"
+      }
     },
-    "gemini-3.1-pro-low": {
-      "displayName": "Gemini 3.1 Pro (Low)",
+    "gemini-2.5-flash-thinking": {
+      "displayName": "Gemini 3.1 Flash Lite",
+      "maxTokens": 1048576,
+      "maxOutputTokens": 65535,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_THINKING",
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      }
+    },
+    "gemini-pro-agent": {
+      "displayName": "Gemini 3.1 Pro (High)",
       "supportsImages": true,
       "supportsThinking": true,
-      "thinkingBudget": 1001,
+      "thinkingBudget": 10001,
       "minThinkingBudget": 128,
       "recommended": true,
       "maxTokens": 1048576,
       "maxOutputTokens": 65535,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "resetTime": "2026-08-12T03:11:27Z"
       },
-      "model": "MODEL_PLACEHOLDER_M36",
+      "model": "MODEL_PLACEHOLDER_M16",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "supportsVideo": true,
       "supportedMimeTypes": {
-        "text/x-typescript": true,
+        "text/rtf": true,
+        "video/jpeg2000": true,
+        "video/text/timestamp": true,
+        "text/html": true,
+        "text/plain": true,
         "audio/webm;codecs=opus": true,
+        "application/x-python-code": true,
+        "application/pdf": true,
+        "text/markdown": true,
+        "text/csv": true,
         "image/webp": true,
+        "video/audio/s16le": true,
         "application/json": true,
+        "video/videoframe/jpeg2000": true,
+        "application/x-ipynb+json": true,
+        "text/javascript": true,
+        "application/x-typescript": true,
+        "image/heic": true,
+        "image/heif": true,
+        "text/css": true,
+        "image/png": true,
+        "video/audio/wav": true,
+        "video/mp4": true,
+        "image/jpeg": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "video/webm": true,
         "application/rtf": true,
         "text/x-python": true,
-        "video/mp4": true,
-        "text/csv": true,
-        "video/text/timestamp": true,
-        "text/css": true,
-        "image/heif": true,
-        "application/x-typescript": true,
-        "text/x-python-script": true,
-        "application/x-python-code": true,
-        "text/plain": true,
-        "video/webm": true,
-        "video/audio/wav": true,
-        "image/jpeg": true,
-        "text/xml": true,
         "application/x-javascript": true,
-        "text/javascript": true,
-        "text/html": true,
-        "video/jpeg2000": true,
-        "image/heic": true,
-        "application/pdf": true,
-        "video/audio/s16le": true,
-        "text/markdown": true,
-        "video/videoframe/jpeg2000": true,
-        "image/png": true,
-        "application/x-ipynb+json": true,
-        "text/rtf": true
+        "text/xml": true
       },
       "modelExperiments": {
         "experiments": {
@@ -717,132 +910,26 @@
           "template__system_prompts__communication_style": {
             "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [filename](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n\nCRITICAL INSTRUCTION 1: You may have access to a variety of tools at your disposal. Some tools may be for a specific task such as 'view_file' (for viewing contents of a file). Others may be very broadly applicable such as the ability to run a command on a terminal. Always prioritize using the most specific tool you can for the task at hand. Here are some rules: (a) NEVER run cat inside a bash command to create a new file or append to an existing file. (b) ALWAYS use grep_search instead of running grep inside a bash command unless absolutely needed. (c) DO NOT use ls for listing, cat for viewing, grep for finding, sed for replacing.\nCRITICAL INSTRUCTION 2: Before making tool calls T, think and explicitly list out any related tools for the task at hand. You can only execute a set of tools T if all other tools in the list are either more generic or cannot be used for the task at hand. ALWAYS START your thought with recalling critical instructions 1 and 2. In particular, the format for the start of your thought block must be '...94>thought\\nCRITICAL INSTRUCTION 1: ...\\nCRITICAL INSTRUCTION 2: ...'."
           },
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
+          "template__system_prompts__planning_mode_artifacts": {
             "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
           }
         }
       }
     },
-    "gemini-3.5-flash-low": {
-      "displayName": "Gemini 3.5 Flash (Low)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 1000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
+    "chat_23310": {
+      "maxTokens": 32768,
       "quotaInfo": {
-        "remainingFraction": 1,
-        "resetTime": "2026-05-29T18:30:05Z"
+        "remainingFraction": 1
       },
-      "model": "MODEL_PLACEHOLDER_M20",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "model": "MODEL_CHAT_23310",
+      "apiProvider": "API_PROVIDER_INTERNAL",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time",
-      "supportedMimeTypes": {
-        "video/mp4": true,
-        "text/x-python": true,
-        "image/heic": true,
-        "application/x-ipynb+json": true,
-        "text/markdown": true,
-        "video/text/timestamp": true,
-        "application/x-javascript": true,
-        "video/videoframe/jpeg2000": true,
-        "text/xml": true,
-        "text/x-python-script": true,
-        "image/heif": true,
-        "application/rtf": true,
-        "video/jpeg2000": true,
-        "application/pdf": true,
-        "text/css": true,
-        "application/json": true,
-        "image/webp": true,
-        "text/csv": true,
-        "text/javascript": true,
-        "text/plain": true,
-        "video/audio/wav": true,
-        "image/png": true,
-        "application/x-python-code": true,
-        "video/audio/s16le": true,
-        "audio/webm;codecs=opus": true,
-        "video/webm": true,
-        "image/jpeg": true,
-        "text/rtf": true,
-        "text/html": true,
-        "application/x-typescript": true,
-        "text/x-typescript": true
-      },
-      "modelExperiments": {
-        "experiments": {
-          "template__system_prompts__identity": {
-            "stringValue": "You are Antigravity, a powerful agentic AI coding assistant designed by the Google DeepMind team working on Advanced Agentic Coding.\nYou are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.\nThe USER will send you requests, which you must always prioritize addressing. User requests are enclosed within <USER_REQUEST> tags. Along with each USER request, we will attach additional metadata about their current state, such as what files they have open and where their cursor is.\nThis information may or may not be relevant to the coding task, it is up for you to decide."
-          },
-          "template__system_prompts__planning_more_artifacts": {
-            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
-          },
-          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
-            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"100000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": true,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": true,\n    \"include_conversation_log\": false,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
-          }
-        }
-      }
-    },
-    "gemini-3.5-flash-medium": {
-      "displayName": "Gemini 3.5 Flash (Medium)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 4000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "model": "MODEL_PLACEHOLDER_M16",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time"
-    },
-    "gemini-3.5-flash-high": {
-      "displayName": "Gemini 3.5 Flash (High)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 10000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "model": "MODEL_PLACEHOLDER_M16",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time"
-    },
-    "gemini-3.6-flash-low": {
-      "displayName": "Gemini 3.6 Flash (Low)",
-      "supportsImages": true,
-      "supportsThinking": true,
-      "thinkingBudget": 1000,
-      "minThinkingBudget": 32,
-      "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "model": "MODEL_PLACEHOLDER_M16",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time"
+      "supportsCumulativeContext": true,
+      "supportsEstimateTokenCounter": true,
+      "isInternal": true,
+      "promptTemplaterType": "PROMPT_TEMPLATER_TYPE_CHATML",
+      "toolFormatterType": "TOOL_FORMATTER_TYPE_XML",
+      "requiresLeadInGeneration": true
     },
     "gemini-3.6-flash-medium": {
       "displayName": "Gemini 3.6 Flash (Medium)",
@@ -853,41 +940,121 @@
       "recommended": true,
       "maxTokens": 1048576,
       "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "model": "MODEL_PLACEHOLDER_M16",
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M72",
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "supportsVideo": true,
       "tagTitle": "Fast",
-      "tagDescription": "Limited time"
+      "tagDescription": "Limited time",
+      "supportedMimeTypes": {
+        "application/x-javascript": true,
+        "audio/webm;codecs=opus": true,
+        "application/x-ipynb+json": true,
+        "image/png": true,
+        "text/x-python": true,
+        "image/heic": true,
+        "text/x-typescript": true,
+        "application/x-python-code": true,
+        "image/jpeg": true,
+        "video/audio/s16le": true,
+        "video/videoframe/jpeg2000": true,
+        "text/html": true,
+        "text/markdown": true,
+        "video/text/timestamp": true,
+        "video/jpeg2000": true,
+        "image/webp": true,
+        "application/rtf": true,
+        "text/rtf": true,
+        "application/pdf": true,
+        "application/json": true,
+        "video/mp4": true,
+        "text/plain": true,
+        "text/javascript": true,
+        "video/webm": true,
+        "text/x-python-script": true,
+        "application/x-typescript": true,
+        "image/heif": true,
+        "text/xml": true,
+        "text/csv": true,
+        "text/css": true,
+        "video/audio/wav": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": false,\n    \"disabledHeuristics\": [\"planning_mode\", \"bash_command_reminder\", \"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
+          },
+          "template__system_prompts__communication_style": {
+            "stringValue": "- Keep your responses concise.\n- Provide a summary of your work when you end your turn.\n- Format your responses in github-style markdown.\n- You can render LaTeX math (KaTeX): inline with `\\(...\\)` or `$...$`, display with `\\[...\\]` or `$$...$$` placed on its own line.\n- Use math only for genuine mathematical content. Use backticks for code, identifiers, paths, flags, and shell variables.\n- `$` opens inline math, so write a literal dollar as `\\$` or wrap it in backticks. Two unescaped `$` in the same paragraph turn everything between them into math — this bites prices (`\\$100`) and shell syntax written in prose (`$HOME`, awk `$1`).\n- If you're unsure about the user's intent, ask for clarification rather than making assumptions.\n- You MUST create clickable links for all files and code symbols (classes, types, functions, structs). Use github style markdown links with the `file://` scheme (e.g., [utils.py](file:///path/to/file) or [ClassName](file:///path/to/file#L10-L20)`). For Windows, use forward slashes for paths.\n- After launching a background task such as 'run_command', YOU MUST TAKE ONE OF THE FOLLOWING TWO ACTIONS: \nA) either proceed to other relevant work (if any) or, \nB) simply update the user with a short message (e.g. 'task-20 has been launched in the background. I will wait for it to complete before proceeding.') and end the turn.\nDO NOTHING ELSE.\n"
+          },
+          "template__system_prompts__guidelines": {
+            "stringValue": "Follow these behavioral and workflow guidelines at all times:\n# Documentation\n- Maintain documentation integrity. Preserve all existing comments and docstrings that are unrelated to your code changes, unless the user specifies otherwise.\n\n# Obey Explicit Directives\nIf the user specifies precise quantitative filtering rules, layout boundaries, or architectural preferences, enforce them exactly as requested without alteration.\n\n# Never Guess Code Logic, Schemas, or File Paths\nNEVER infer implementation details, variable names, or file locations without inspecting the authoritative source using code search and file viewing tools.\n\n# Inspect Logs & Stack Traces Before Diagnosing Errors\nNEVER form a diagnostic hypothesis for a runtime failure, or test breakage, without reading the full, un-truncated error log. When an error occurs, your VERY FIRST ACTION must be to fetch and read the exact logs. Base your diagnosis strictly on empirical log evidence.\n\n# No Superficial Symptom Patches\nNEVER resolve errors by masking symptoms, swallowing exceptions, returning dummy fallbacks, commenting out broken assertions, or deleting failing unit tests. When a test or function fails, identify why the underlying contract was broken. If an API returns missing or null data, trace the upstream data provider instead of wrapping the call in a silent try/except or returning an empty 0-byte ArrayBuffer.\n\n# Never Declare Success Without Running Verification Commands\nNEVER claim a task is resolved, a bug is fixed, or a feature is working until you have gathered concrete, empirical runtime verification demonstrating clean success. Editing a file does not equal completing the task. You MUST run the build or test command afterwards.\n\n# Never Ignore Explicit Command Failures or Error Exit Codes\nIf a command fails, you MUST explicitly acknowledge the failure to the user or continue debugging. Never gloss over a build timeout or permission denied error by focusing only on the part of the code that compiled.\n\n# Check Feature Flags & Enforce Strict Control Flow Scoping\nWhenever modifying conditional branches, adding experimental features, or processing loops, ensure that new logic is strictly scoped and evaluated against all possible execution paths.\n\n# Preserve Existing API Contracts & Avoid Unintended Side Effects\nIf you modify a function signature, use code search to find and update every invocation site so the parameter is actually passed.\n\n# Silent Log Inspection & Professional Synthesis\nWhen background tasks (run_command async, manage_task, schedule) complete or emit log notifications, inspect the log files silently. Summarize and synthesize the exact findings in clean, professional natural language.\n\n# No Snippet Tunnel Vision\nNever infer the definition of data structures (proto, struct, class, or enum schemas) from partial file views (first 15 lines or L40-L65 snippets) or design doc text.\nIf view_file output indicates truncation or if an imported schema is referenced, you MUST adjust StartLine/EndLine or ContentOffset to inspect the complete, exact definition of the target symbols before writing code that consumes them.\n\n# Check Command Registries\nWhenever modifying core C/C++/Java command implementations (CLIENT LIST, CLIENT KILL), explicitly search for and update corresponding command definitions across all registry files (commands.def, JSON schemas, .bzl build manifests).\n\n# Audit Before Re-inventing\nSearch the codebase and recent commit history for pre-existing utility classes or decoupled architecture before writing custom helper classes from scratch.\n\n# No Blocking Calls on Main Looper Threads\nNever invoke blocking thread synchronizations (webLatch.await(500, ...), Future.get()) on main Android UI loops or single-threaded event dispatchers. \n\n# Thread Pool Shutdown Safety\nWhen modifying worker thread loops or shared queues, ensure emergency stop/shutdown signals and loop termination criteria remain intact so thread join operations never deadlock.\n\n# Exact Argument Structure\nPass arguments exactly as expected by the API (calculateRoute({ origin, destination, travelMode }) vs calculateRoute(origin, destination, travelMode)).\n\n# Local State Mutation Only\nDo not mutate private third-party DOM properties. Do not push incomplete draft objects directly into global array states; keep transient state within local component state.\n\n# Traceback Justification Required\nEvery code or configuration edit during debugging MUST be justified by an explicit error traceback, log line, or verified root cause. If the root cause is unknown, investigate further before mutating code.\n\n# Analyze Before Retrying\nNever repeat the exact same broken test or shell command line with duplicate/conflicting arguments without analyzing and resolving why the previous command failed.\n\n# Persevere on Log Extraction\nIf a log retrieval command fails, NEVER abandon log extraction to diagnose blindly. Immediately switch to alternative tools to inspect the actual failure traceback.\n\n# Verify Signatures & Prop Names\nCheck exact variable names, component prop keys, and method signatures before passing them. Prevent NullPointerException, AttributeError, KeyError, and ReferenceError crashes by explicitly verifying object initialization and non-null states before property dereferencing (layer._path, stat.owner()).\n\n# Dynamic Layout Math\nAvoid hardcoding static pixel offsets (+ 12) or arbitrary multipliers (pill_font_size * 2.0) when computing dynamic UI layout heights; calculate exact container bounds from wrapped elements.\n"
+          },
+          "template__system_prompts__messaging": {
+            "stringValue": "You are connected to a messaging system where you may receive messages from: {{- $subagent := .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled -}}\n{{- $message := .CascadeConfig.GetMessageConfig.GetEnabled -}}\n{{- if and $subagent $message }} agents, background tasks, user-queued messages\n{{- else if $subagent }} agents, background tasks\n{{- else if $message }} background tasks, user-queued messages\n{{- else }} background tasks\n{{- end }}.\n\n## Receiving Messages\n\nYou receive messages automatically at the start of each invocation. All messages are delivered in full directly into your context — no manual retrieval is needed.\n\n## Reactive Wakeup (No Polling Needed)\n\nThe system automatically resumes your execution when:\n{{- if .CascadeConfig.GetPlannerConfig.GetToolConfig.GetInvokeSubagent.GetEnabled }}\n- A message arrives from a subagent or peer agent\n{{- end }}\n- A **background task** completes or sends you a notification\n{{- if .CascadeConfig.GetMessageConfig.GetEnabled }}\n- A **user-queued message** is ready to be dequeued\n{{- end }}\n\nThis means you do **NOT** need to poll in a loop while waiting for messages or updates. After launching a task that runs in the background, you may continue other work or simply stop by calling no more tools. The system will notify you when there is something to process."
+          },
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          }
+        }
+      }
     },
-    "gemini-3.6-flash-high": {
-      "displayName": "Gemini 3.6 Flash (High)",
+    "claude-sonnet-4-6": {
+      "displayName": "Claude Sonnet 4.6 (Thinking)",
       "supportsImages": true,
       "supportsThinking": true,
-      "thinkingBudget": 10000,
-      "minThinkingBudget": 32,
+      "thinkingBudget": 1024,
       "recommended": true,
-      "maxTokens": 1048576,
-      "maxOutputTokens": 65536,
-      "tokenizerType": "LLAMA_WITH_SPECIAL",
-      "model": "MODEL_PLACEHOLDER_M16",
-      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "modelProvider": "MODEL_PROVIDER_GOOGLE",
-      "supportsVideo": true,
-      "tagTitle": "Fast",
-      "tagDescription": "Limited time"
+      "maxTokens": 250000,
+      "maxOutputTokens": 64000,
+      "quotaInfo": {
+        "remainingFraction": 1,
+        "resetTime": "2026-08-12T03:11:27Z"
+      },
+      "model": "MODEL_PLACEHOLDER_M35",
+      "apiProvider": "API_PROVIDER_ANTHROPIC_VERTEX",
+      "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
+      "supportedMimeTypes": {
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "video/jpeg2000": true,
+        "video/videoframe/jpeg2000": true
+      },
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_UNSPECIFIED\",\n    \"max_token_limit\": \"160000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    }\n}"
+          },
+          "template__system_prompts__planning_mode_artifacts": {
+            "stringValue": "When in planning mode, you will work with three special artifacts.\n\n# Tasks\nPath: {{ArtifactDirectoryPath}}/task.md\n\n**Purpose**: A TODO list to organize your work during execution. Create this artifact after receiving user approval on your implementation plan. Break down complex tasks into component-level items and track progress as a living document.\n\n**Format**:\n```markdown\n- `[ ]` uncompleted tasks\n- `[/]` in progress tasks (custom notation)\n- `[x]` completed tasks\n- Use indented lists for sub-items\n```\n\n**Updating task.md**: Mark items as `[/]` when starting work on them, and `[x]` when completed. Update task.md as you make progress through your checklist.\n\n# Implementation Plan\nPath: {{ArtifactDirectoryPath}}/implementation_plan.md\n\n**Purpose**: A detailed design document to present your technical implementation plan to the user for feedback and approval.\nAfter reading the document, the user should understand the key technical details of your plan, and be able to make an informed decision on whether to approve it.\n\n**Format**: Use the following format, omitting any irrelevant sections.\n```markdown\n# [Goal Description]\n\nProvide a brief description of the problem, any background context, and what the change accomplishes.\n\n## User Review Required\n\nDocument anything that requires user review or feedback, for example, breaking changes or significant design decisions. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Open Questions\n\nAny clarifying or design questions for the user that will impact the implementation plan. Use GitHub alerts (IMPORTANT/WARNING/CAUTION) to highlight critical items.\n\n## Proposed Changes\n\nGroup files by component (e.g., package, feature area, dependency layer) and order logically (dependencies first). Separate components with horizontal rules for visual clarity.\n\n### [Component Name]\n\nSummary of what will change in this component, separated by files. For specific files, Use [NEW] and [DELETE] to demarcate new and deleted files, for example:\n\n#### [MODIFY] [file basename](file:///absolute/path/to/modifiedfile)\n#### [NEW] [file basename](file:///absolute/path/to/newfile)\n#### [DELETE] [file basename](file:///absolute/path/to/deletedfile)\n\n## Verification Plan\n\nSummary of how you will verify that your changes have the desired effects.\n\n### Automated Tests\n- The commands of any automated tests you'll run.\n\n### Manual Verification\n- Asking the user to deploy to staging and testing, verifying UI changes on an iOS app etc.\n```\n\n# Walkthrough\nPath: {{ArtifactDirectoryPath}}/walkthrough.md\n\n**Purpose**: After completing work, summarize what you accomplished. Update an existing walkthrough for related follow-up work rather than creating a new one.\n\n**Document**:\n- Changes made\n- What was tested\n- Validation results\n\nEmbed screenshots and recordings to visually demonstrate UI changes and user flows.\n"
+          }
+        }
+      },
+      "vertexModelId": "claude-sonnet-4-6@default"
     }
   },
-  "defaultAgentModelId": "gemini-3.5-flash",
+  "defaultAgentModelId": "gemini-3.6-flash-high",
   "agentModelSorts": [
     {
       "displayName": "Recommended",
       "groups": [
         {
           "modelIds": [
-            "gemini-3.5-flash",
-            "gemini-3.1-pro",
+            "gemini-3.6-flash-high",
+            "gemini-3.6-flash-medium",
+            "gemini-3.6-flash-low",
+            "gemini-3-flash-agent",
+            "gemini-3.5-flash-low",
+            "gemini-3.5-flash-extra-low",
+            "gemini-pro-agent",
+            "gemini-3.1-pro-low",
             "claude-sonnet-4-6",
             "claude-opus-4-6-thinking",
             "gpt-oss-120b-medium"
@@ -923,46 +1090,64 @@
     "gemini-3.1-flash-lite"
   ],
   "audioTranscriptionModelIds": [
-    "models/proactive-observer"
+    "models/proactive-observer-v10"
   ],
   "experimentIds": [
-    106101246,
-    106168863,
+    106571595,
+    106409969,
+    106140402,
     105979552,
     105979574,
     106015333,
     105979579,
+    106568772,
+    106568778,
     105867471,
+    106548982,
     106123599,
     106076629,
+    106121401,
     106100625,
-    105930909,
     106143956,
     105879567,
     105856899,
+    106312323,
     106064030,
+    106567313,
+    106396310,
     105757908,
-    106240760,
     106106760,
     106021688,
     106014288,
     105887299,
+    106283618,
+    106568766,
     106278607,
+    106538964,
+    106512082,
+    106380926,
     106212376,
     106281951,
     106264532,
+    106222835,
     106044947,
     106032303,
     106228452,
-    106121606,
+    106121607,
     105979531,
     105979553,
     106015328,
+    106568390,
+    106568396,
     105867469,
     106123597,
+    106121399,
     106100654,
     106064028,
-    106240748,
+    106567309,
+    106396304,
+    106283614,
+    106568384,
     106038164,
     106032301,
     106121604
@@ -972,7 +1157,7 @@
       "gemini-3.1-flash-lite"
     ],
     "flash": [
-      "gemini-3-flash-agent"
+      "gemini-3.6-flash-tiered"
     ],
     "pro": [
       "gemini-3.1-pro-low"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthonyhaussman/opencode-agy-auth",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/google": "^4.0.39",
+        "@ai-sdk/google": "^4.0.41",
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.18.15"
+        "@opencode-ai/plugin": "^1.18.16"
       },
       "devDependencies": {
-        "@opencode-ai/sdk": "^1.18.15",
+        "@opencode-ai/sdk": "^1.18.16",
         "@types/node": "^26.2.0",
         "tsup": "^8.5.1",
         "typescript": "^7.0.2"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.39.tgz",
-      "integrity": "sha512-+mRx7UBZn9PkJ4J6YXowaRZKMZYa290cknVqqOw/roZaDg186IUOLn9JHNQkvgaj91/MLW1AZNESy1ZD2yXDCg==",
+      "version": "4.0.42",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.42.tgz",
+      "integrity": "sha512-wFo4SmIEKd7kr+x0HvIRQG1E5ye+aW+Lqsg2IM54de4YxaN27iXb7AAvAvp496MNar7DrxgE1QHQ0vZ7hMFG3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.7",
-        "@ai-sdk/provider-utils": "5.0.25"
+        "@ai-sdk/provider-utils": "5.0.27"
       },
       "engines": {
         "node": ">=22"
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.25.tgz",
-      "integrity": "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.27.tgz",
+      "integrity": "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.7",
@@ -671,13 +671,13 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.15.tgz",
-      "integrity": "sha512-AY10RtFbzLkf951dbLkSGJdBeddeS6ojbjvqCpWnINedqlj2cK/GF91xWjWnlHpqQZ4GABLPCuoSJx8mGmKvCw==",
+      "version": "1.18.16",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.16.tgz",
+      "integrity": "sha512-XvlZ9CFAXqrNrmpTe+EhhRYnDhca6db1ebcB10v5JO8kSm1iFbVbPP982Qzc4MRSrfpPjD8W1fg13Ubnff377g==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.15",
+        "@opencode-ai/sdk": "1.18.16",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -699,9 +699,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.15",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.15.tgz",
-      "integrity": "sha512-8sfo9nGiVwesAZW9Wqkvynyn7w4wYaHx1O9qOHpYL65+Bs2XUpHP3kBbZe58gjQydFgk6I74kUF7sqCiPu2arQ==",
+      "version": "1.18.16",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.16.tgz",
+      "integrity": "sha512-UvaHyL93spLm7MttoprWTOBSYQN3aYWd7/3Ie5WNnG2pRAPq/U/d51qt0smYBTrkjxqlQmg+AJoGw8MEH6lGUg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anthonyhaussman/opencode-agy-auth",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "author": "antigravity",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -21,18 +21,19 @@
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
     "typecheck": "tsc",
+    "models:refresh": "node scripts/fetch-models.mjs",
     "smoke:node-import": "node -e \"import('./dist/index.js').then(() => console.log('ok')).catch((error) => { console.error(error); process.exit(1); })\"",
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@opencode-ai/sdk": "^1.18.15",
+    "@opencode-ai/sdk": "^1.18.16",
     "@types/node": "^26.2.0",
     "tsup": "^8.5.1",
     "typescript": "^7.0.2"
   },
   "dependencies": {
-    "@ai-sdk/google": "^4.0.39",
+    "@ai-sdk/google": "^4.0.41",
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.18.15"
+    "@opencode-ai/plugin": "^1.18.16"
   }
 }

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Refreshes models.json from a fresh fetchAvailableModels API call.
+ *
+ * Reads the OAuth refresh token from the opencode plugin's auth storage
+ * (~/.local/share/opencode/auth.json under the "google-agy" key), refreshes
+ * the access token, then calls the Antigravity Code Assist endpoint to get
+ * the current internal model catalog and writes it to models.json.
+ *
+ * Usage:
+ *   node scripts/fetch-models.mjs [--endpoint <url>] [--output <path>] [--verbose]
+ *
+ * Flags:
+ *   --endpoint <url>   Override the Code Assist endpoint
+ *                      (default: https://daily-cloudcode-pa.googleapis.com)
+ *   --output <path>    Write to a different file (default: <repo>/models.json)
+ *   --verbose          Emit progress to stderr
+ *
+ * Exit codes:
+ *   0  Success
+ *   1  Token refresh failed
+ *   2  API response not OK
+ *   3  Fetch / I/O error
+ *
+ * Requires Node >= 18 (uses built-in fetch with HTTP/2).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
+const AGY_CLIENT_SECRET = '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';
+const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
+const AGY_API_VERSION = '1.1.12';
+
+function parseArgs(argv) {
+  const args = { endpoint: null, output: null, verbose: false };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--endpoint') {
+      args.endpoint = argv[++i];
+    } else if (arg === '--output') {
+      args.output = argv[++i];
+    } else if (arg === '--verbose') {
+      args.verbose = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node scripts/fetch-models.mjs [--endpoint <url>] [--output <path>] [--verbose]');
+      process.exit(0);
+    } else {
+      console.error(`Unknown flag: ${arg}`);
+      process.exit(1);
+    }
+  }
+  return args;
+}
+
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  for (let depth = 0; depth < 20; depth++) {
+    try {
+      readFileSync(join(dir, 'package.json'), 'utf8');
+      return dir;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return startDir;
+}
+
+function logVerbose(args, ...msg) {
+  if (args.verbose) console.error(...msg);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = findRepoRoot(scriptDir);
+  const endpoint = args.endpoint || DEFAULT_ENDPOINT;
+  const outputPath = args.output ? resolve(args.output) : join(repoRoot, 'models.json');
+
+  const userAgent = `antigravity/cli/${AGY_API_VERSION} linux/${process.arch === 'x64' ? 'amd64' : process.arch}`;
+
+  const authPath = join(homedir(), '.local/share/opencode/auth.json');
+  logVerbose(args, `[fetch-models] reading auth from ${authPath}`);
+
+  let auth;
+  try {
+    auth = JSON.parse(readFileSync(authPath, 'utf8'));
+  } catch (err) {
+    console.error(`Failed to read auth.json at ${authPath}: ${err.message}`);
+    process.exit(3);
+  }
+
+  const agyAuth = auth['google-agy'];
+  if (!agyAuth || !agyAuth.refresh) {
+    console.error('No google-agy OAuth refresh token found in auth.json');
+    process.exit(1);
+  }
+
+  const refreshRaw = agyAuth.refresh;
+  const [refreshToken, projectId, managedProjectId] = refreshRaw.split('|');
+
+  if (!refreshToken) {
+    console.error('Refresh token is empty');
+    process.exit(1);
+  }
+  if (!managedProjectId) {
+    console.error('managedProjectId (third pipe-separated field of refresh) is missing');
+    process.exit(1);
+  }
+
+  logVerbose(args, `[fetch-models] refreshToken: ${refreshToken.substring(0, 10)}...`);
+  logVerbose(args, `[fetch-models] projectId: ${projectId}`);
+  logVerbose(args, `[fetch-models] managedProjectId: ${managedProjectId}`);
+  logVerbose(args, `[fetch-models] endpoint: ${endpoint}`);
+  logVerbose(args, `[fetch-models] output: ${outputPath}`);
+  logVerbose(args, `[fetch-models] userAgent: ${userAgent}`);
+
+  logVerbose(args, '[fetch-models] refreshing access token...');
+  const refreshBody = new URLSearchParams({
+    client_id: AGY_CLIENT_ID,
+    client_secret: AGY_CLIENT_SECRET,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  });
+
+  let token;
+  try {
+    const refreshResp = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: refreshBody.toString(),
+    });
+    if (!refreshResp.ok) {
+      const errText = await refreshResp.text();
+      console.error(`Token refresh failed (${refreshResp.status} ${refreshResp.statusText}): ${errText}`);
+      process.exit(1);
+    }
+    token = await refreshResp.json();
+  } catch (err) {
+    console.error(`Token refresh fetch error: ${err.message}`);
+    process.exit(3);
+  }
+
+  if (!token.access_token) {
+    console.error(`Token refresh returned no access_token: ${JSON.stringify(token)}`);
+    process.exit(1);
+  }
+
+  const accessToken = token.access_token;
+  logVerbose(args, `[fetch-models] got access token: ${accessToken.substring(0, 10)}...`);
+
+  const url = `${endpoint}/v1internal:fetchAvailableModels`;
+  const body = JSON.stringify({ project: managedProjectId });
+  logVerbose(args, `[fetch-models] calling ${url} with body: ${body}`);
+
+  let data;
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': userAgent,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+    logVerbose(args, `[fetch-models] response status: ${resp.status} ${resp.statusText}`);
+    if (!resp.ok) {
+      const errText = await resp.text();
+      console.error(`fetchAvailableModels failed (${resp.status} ${resp.statusText}): ${errText.substring(0, 1000)}`);
+      process.exit(2);
+    }
+    data = await resp.json();
+  } catch (err) {
+    console.error(`fetchAvailableModels fetch error: ${err.message}`);
+    process.exit(3);
+  }
+
+  const modelCount = data.models ? Object.keys(data.models).length : 0;
+  logVerbose(args, `[fetch-models] received ${modelCount} models, writing to ${outputPath}`);
+
+  try {
+    writeFileSync(outputPath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+  } catch (err) {
+    console.error(`Failed to write ${outputPath}: ${err.message}`);
+    process.exit(3);
+  }
+
+  console.log(`Wrote ${modelCount} models to ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error(`Unexpected error: ${err.stack || err.message || err}`);
+  process.exit(3);
+});

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.11';
+export const AGY_CLI_VERSION = '1.1.12';


### PR DESCRIPTION
Update the plugin to match agy CLI version 1.1.12.
This includes bumping core dependencies and refreshing models.json with the latest catalog, which introduces the 3.6-flash tiered models and sets the default agent model to gemini-3.6-flash-high.

Additionally, this adds AGENTS.md to document the bump workflow and a new scripts/fetch-models.mjs Node script to reliably automate fetching the internal model catalog without HTTP/1.0 curl fallback issues.
