### PR TITLE
feat(request): map tool name schemas for gemini api

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,12 +4,12 @@
       "release-type": "node",
       "include-component-in-tag": false,
       "tag-separator": "",
-      "prerelease": false,
+      "prerelease": true,
       "prerelease-type": "alpha",
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.13"
+      "release-as": "1.1.14-alpha.0"
     }
   },
   "changelog-types": [

--- a/src/sdk/request/index.ts
+++ b/src/sdk/request/index.ts
@@ -10,3 +10,10 @@ export { transformAgyResponse } from "./response";
 export { isGenerativeLanguageRequest, parseGenerativeLanguageRequest } from "./shared";
 export { initTurnStateTracker, getTurnStateTracker, shutdownTurnStateTracker, TurnStateTracker } from "./turn-state-tracker";
 export type { TurnState } from "./turn-state-tracker";
+export {
+  ToolMapper,
+  getToolMapper,
+  sanitizeToolName,
+  restoreToolNamesInResponse,
+  clearToolMapper,
+} from "./tool-mapper";

--- a/src/sdk/request/openai.ts
+++ b/src/sdk/request/openai.ts
@@ -7,6 +7,8 @@
  * allowing the plugin to simply call and forward standard OpenAI formatted requests and response streams.
  */
 
+import type { ToolMapper } from "./tool-mapper";
+
 interface GeminiFunctionCallPart {
   functionCall?: {
     id?: string;
@@ -37,7 +39,7 @@ interface OpenAIMessage {
 /**
  * Converts OpenAI's `tool_calls` into Gemini's `functionCall` sections.
  */
-export function transformOpenAIToolCalls(requestPayload: Record<string, unknown>): void {
+export function transformOpenAIToolCalls(requestPayload: Record<string, unknown>, toolMapper?: ToolMapper): void {
   const messages = requestPayload.messages;
   if (!messages || !Array.isArray(messages)) {
     return;
@@ -69,11 +71,12 @@ export function transformOpenAIToolCalls(requestPayload: Record<string, unknown>
         continue;
       }
 
-      const name = fn.name;
+      const rawName = fn.name ?? "";
+      const name = toolMapper ? toolMapper.toGemini(rawName) : rawName;
       const args = parseJsonObject(fn.arguments);
 
       const functionCallPart: NonNullable<GeminiFunctionCallPart['functionCall']> = {
-        name: name ?? "",
+        name,
         args,
       };
 

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -10,6 +10,7 @@ import { isGenerativeLanguageRequest, parseGenerativeLanguageRequest } from "./s
 import { getLatestSignature } from "../../plugin/cache";
 import { closeToolLoopForThinking } from "./thinking";
 import { getTurnStateTracker } from "./turn-state-tracker";
+import { getToolMapper, sanitizeToolName, type ToolMapper } from "./tool-mapper";
 
 const STREAM_ACTION = "streamGenerateContent";
 
@@ -142,9 +143,13 @@ function transformRequestBody(
       }
 
       const { userPromptId, sessionId, requestId } = normalizeWrappedIdentifiers(wrappedBody);
+      const toolMapper = getToolMapper(sessionId);
 
       const requestPayloadInside = wrappedBody.request as Record<string, unknown> | undefined;
       if (requestPayloadInside) {
+        toolMapper.registerFromFunctionDeclarations(requestPayloadInside.tools);
+        toolMapper.registerFromContents(requestPayloadInside.contents);
+
         normalizeThinking(
           requestPayloadInside,
           resolveDefaultThinkingConfig(thinkingConfigDefaults, requestedModel, effectiveModel),
@@ -163,11 +168,15 @@ function transformRequestBody(
       }
 
       if (requestPayloadInside && Array.isArray(requestPayloadInside.tools)) {
-        normalizeToolSchemaTypes(requestPayloadInside.tools);
+        normalizeToolSchemaTypes(requestPayloadInside.tools, toolMapper);
+      }
+      if (requestPayloadInside) {
+        normalizeToolConfig(requestPayloadInside, toolMapper);
       }
       if (requestPayloadInside && Array.isArray(requestPayloadInside.contents)) {
         let contents = requestPayloadInside.contents;
 
+        normalizeToolNamesInContents(contents, toolMapper);
         injectMissingToolCallIds(contents);
         fixOrphanedFunctionResponses(contents);
 
@@ -192,10 +201,18 @@ function transformRequestBody(
     }
 
     const requestPayload = { ...parsedBody };
+    const { userPromptId, sessionId, requestId } = normalizeRequestPayloadIdentifiers(requestPayload);
+    const toolMapper = getToolMapper(sessionId);
+
+    toolMapper.registerFromOpenAITools(requestPayload.tools);
+    toolMapper.registerFromFunctionDeclarations(requestPayload.tools);
+    toolMapper.registerFromContents(requestPayload.contents);
+
     if (Array.isArray(requestPayload.tools)) {
-      normalizeToolSchemaTypes(requestPayload.tools);
+      normalizeToolSchemaTypes(requestPayload.tools, toolMapper);
     }
-    transformOpenAIToolCalls(requestPayload);
+    normalizeToolConfig(requestPayload, toolMapper);
+    transformOpenAIToolCalls(requestPayload, toolMapper);
     addThoughtSignaturesToFunctionCalls(requestPayload);
     normalizeThinking(
       requestPayload,
@@ -205,10 +222,9 @@ function transformRequestBody(
     normalizeSystemInstruction(requestPayload);
     normalizeCachedContent(requestPayload);
 
-    const { userPromptId, sessionId, requestId } = normalizeRequestPayloadIdentifiers(requestPayload);
-
     let contents = requestPayload.contents as any[];
     if (Array.isArray(contents)) {
+      normalizeToolNamesInContents(contents, toolMapper);
       injectMissingToolCallIds(contents);
       fixOrphanedFunctionResponses(contents);
 
@@ -360,7 +376,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function normalizeToolSchemaTypes(tools: unknown): void {
+function normalizeToolSchemaTypes(tools: unknown, toolMapper?: ToolMapper): void {
   if (!Array.isArray(tools)) return;
 
   const validSchemaKeys = new Set([
@@ -412,7 +428,7 @@ function normalizeToolSchemaTypes(tools: unknown): void {
     if (tool && Array.isArray(tool.functionDeclarations)) {
       for (const fn of tool.functionDeclarations) {
         if (fn && typeof fn.name === "string") {
-          fn.name = fn.name.replace(/[^a-zA-Z0-9_]/g, "_");
+          fn.name = toolMapper ? toolMapper.toGemini(fn.name) : sanitizeToolName(fn.name);
         }
         if (fn) {
           if (!fn.parameters) {
@@ -420,6 +436,41 @@ function normalizeToolSchemaTypes(tools: unknown): void {
           }
           sanitizeSchema(fn.parameters);
         }
+      }
+    }
+  }
+}
+
+function normalizeToolConfig(requestPayload: Record<string, unknown>, toolMapper: ToolMapper): void {
+  const toolConfig = (requestPayload.toolConfig ?? requestPayload.tool_config) as Record<string, unknown> | undefined;
+  if (!toolConfig || typeof toolConfig !== "object") return;
+
+  const fnCallingConfig = (toolConfig.functionCallingConfig ?? toolConfig.function_calling_config) as Record<string, unknown> | undefined;
+  if (!fnCallingConfig || typeof fnCallingConfig !== "object") return;
+
+  const allowedNames = (fnCallingConfig.allowedFunctionNames ?? fnCallingConfig.allowed_function_names) as string[] | undefined;
+  if (Array.isArray(allowedNames)) {
+    const mapped = allowedNames.map((name) => (typeof name === "string" ? toolMapper.toGemini(name) : name));
+    if (fnCallingConfig.allowedFunctionNames) {
+      fnCallingConfig.allowedFunctionNames = mapped;
+    }
+    if (fnCallingConfig.allowed_function_names) {
+      fnCallingConfig.allowed_function_names = mapped;
+    }
+  }
+}
+
+function normalizeToolNamesInContents(contents: any[], toolMapper: ToolMapper): void {
+  if (!Array.isArray(contents)) return;
+  for (const msg of contents) {
+    if (!msg || typeof msg !== "object" || !Array.isArray(msg.parts)) continue;
+    for (const part of msg.parts) {
+      if (!part || typeof part !== "object") continue;
+      if (part.functionCall && typeof part.functionCall.name === "string") {
+        part.functionCall.name = toolMapper.toGemini(part.functionCall.name);
+      }
+      if (part.functionResponse && typeof part.functionResponse.name === "string") {
+        part.functionResponse.name = toolMapper.toGemini(part.functionResponse.name);
       }
     }
   }

--- a/src/sdk/request/response.ts
+++ b/src/sdk/request/response.ts
@@ -11,6 +11,7 @@ import { cacheSignature } from "../../plugin/cache";
 import { createStreamingTransformer, defaultSignatureStore } from "./thinking";
 import { getTurnStateTracker, type TurnState } from "./turn-state-tracker";
 import type { ChatLogger } from "../chat-logger";
+import { getToolMapper, restoreToolNamesInResponse } from "./tool-mapper";
 
 /**
  * Normalizes Gemini/Agy responses, preserving request metadata and usage counters.
@@ -80,6 +81,11 @@ export async function transformAgyResponse(
         ? injectResponseIdFromTrace(effectiveBodyRaw as Record<string, unknown>)
         : effectiveBodyRaw;
 
+    if (effectiveBody) {
+      const toolMapper = getToolMapper(sessionId);
+      restoreToolNamesInResponse(effectiveBody, toolMapper);
+    }
+
     attachUsageHeaders(headers, effectiveBody);
 
     if (!parsed) {
@@ -144,6 +150,8 @@ function transformStreamingPayloadStream(
     },
     transformThinkingParts: (response: unknown) => {
       if (response && typeof response === "object") {
+        const toolMapper = getToolMapper(sessionId);
+        restoreToolNamesInResponse(response, toolMapper);
         return injectResponseIdFromTrace(response as Record<string, unknown>);
       }
       return response;

--- a/src/sdk/request/tool-mapper.ts
+++ b/src/sdk/request/tool-mapper.ts
@@ -1,0 +1,202 @@
+/**
+ * Tool Name Schema Mapping for Gemini API
+ *
+ * Gemini API tool schemas strictly enforce function names matching `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+ * Agent frameworks (MCP servers, OpenCode plugins, OpenAI adapters) often use hyphens (-), dots (.),
+ * slashes (/), or colons (:) in tool names (e.g. `context7_resolve_library_id`, `atlassian:get-issue`, `my-tool`).
+ *
+ * This module maintains a bidirectional mapping between original client tool names and Gemini-compliant tool names,
+ * resolving collisions deterministically and persisting session mappings across multi-turn tool loops.
+ */
+
+export function sanitizeToolName(name: string): string {
+  if (!name || typeof name !== "string") {
+    return "unnamed_tool";
+  }
+
+  // Replace all non-alphanumeric and non-underscore characters with '_'
+  let sanitized = name.replace(/[^a-zA-Z0-9_]/g, "_");
+
+  // Ensure starts with [a-zA-Z_]
+  if (!/^[a-zA-Z_]/.test(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+
+  return sanitized;
+}
+
+export class ToolMapper {
+  private originalToSanitized = new Map<string, string>();
+  private sanitizedToOriginal = new Map<string, string>();
+
+  /**
+   * Register a tool name and get its Gemini-compliant sanitized name.
+   * Handles naming collisions by appending a numeric suffix if needed.
+   */
+  register(originalName: string): string {
+    if (!originalName || typeof originalName !== "string") {
+      return originalName;
+    }
+
+    const existing = this.originalToSanitized.get(originalName);
+    if (existing) {
+      return existing;
+    }
+
+    const baseSanitized = sanitizeToolName(originalName);
+    let sanitized = baseSanitized;
+    let counter = 1;
+
+    // Resolve collision if a different originalName already claimed this sanitized name
+    while (this.sanitizedToOriginal.has(sanitized) && this.sanitizedToOriginal.get(sanitized) !== originalName) {
+      sanitized = `${baseSanitized}_${counter++}`;
+    }
+
+    this.originalToSanitized.set(originalName, sanitized);
+    this.sanitizedToOriginal.set(sanitized, originalName);
+
+    return sanitized;
+  }
+
+  /**
+   * Map an original tool name to sanitized Gemini name.
+   * If not already registered, registers it on the fly.
+   */
+  toGemini(originalName: string): string {
+    if (!originalName || typeof originalName !== "string") {
+      return originalName;
+    }
+    const sanitized = this.originalToSanitized.get(originalName);
+    if (sanitized) {
+      return sanitized;
+    }
+    return this.register(originalName);
+  }
+
+  /**
+   * Restore a sanitized Gemini tool name back to the original client tool name.
+   */
+  fromGemini(sanitizedName: string): string {
+    if (!sanitizedName || typeof sanitizedName !== "string") {
+      return sanitizedName;
+    }
+    return this.sanitizedToOriginal.get(sanitizedName) ?? sanitizedName;
+  }
+
+  /**
+   * Register tools from Gemini `tools[].functionDeclarations` array.
+   */
+  registerFromFunctionDeclarations(tools: unknown): void {
+    if (!Array.isArray(tools)) return;
+    for (const tool of tools) {
+      if (tool && Array.isArray(tool.functionDeclarations)) {
+        for (const fn of tool.functionDeclarations) {
+          if (fn && typeof fn.name === "string") {
+            this.register(fn.name);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Register tools from OpenAI format `tools[].function.name`.
+   */
+  registerFromOpenAITools(tools: unknown): void {
+    if (!Array.isArray(tools)) return;
+    for (const tool of tools) {
+      if (tool && typeof tool === "object") {
+        const fn = (tool as Record<string, unknown>).function as Record<string, unknown> | undefined;
+        if (fn && typeof fn.name === "string") {
+          this.register(fn.name);
+        }
+      }
+    }
+  }
+
+  /**
+   * Scan contents/messages to register any previously used tool names.
+   */
+  registerFromContents(contents: unknown): void {
+    if (!Array.isArray(contents)) return;
+    for (const content of contents) {
+      if (!content || typeof content !== "object") continue;
+      const parts = (content as Record<string, unknown>).parts;
+      if (Array.isArray(parts)) {
+        for (const part of parts) {
+          if (!part || typeof part !== "object") continue;
+          const p = part as Record<string, unknown>;
+          if (p.functionCall && typeof (p.functionCall as Record<string, unknown>).name === "string") {
+            this.register((p.functionCall as Record<string, unknown>).name as string);
+          }
+          if (p.functionResponse && typeof (p.functionResponse as Record<string, unknown>).name === "string") {
+            this.register((p.functionResponse as Record<string, unknown>).name as string);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Session-based mapper cache
+const sessionMappers = new Map<string, { mapper: ToolMapper; updatedAt: number }>();
+const MAX_SESSION_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export function getToolMapper(sessionId?: string): ToolMapper {
+  if (!sessionId) {
+    return new ToolMapper();
+  }
+
+  const now = Date.now();
+  const existing = sessionMappers.get(sessionId);
+  if (existing && now - existing.updatedAt < MAX_SESSION_AGE_MS) {
+    existing.updatedAt = now;
+    return existing.mapper;
+  }
+
+  // Cleanup old sessions if cache grows large
+  if (sessionMappers.size > 1000) {
+    for (const [key, value] of sessionMappers.entries()) {
+      if (now - value.updatedAt >= MAX_SESSION_AGE_MS) {
+        sessionMappers.delete(key);
+      }
+    }
+  }
+
+  const mapper = new ToolMapper();
+  sessionMappers.set(sessionId, { mapper, updatedAt: now });
+  return mapper;
+}
+
+export function clearToolMapper(sessionId: string): void {
+  sessionMappers.delete(sessionId);
+}
+
+/**
+ * Restores original client tool names inside Gemini candidates/parts functionCall objects.
+ */
+export function restoreToolNamesInResponse(body: unknown, toolMapper: ToolMapper): void {
+  if (!body || typeof body !== "object") return;
+  const b = body as Record<string, unknown>;
+
+  const target = b.response && typeof b.response === "object" ? (b.response as Record<string, unknown>) : b;
+  const candidates = target.candidates;
+  if (Array.isArray(candidates)) {
+    for (const cand of candidates) {
+      if (!cand || typeof cand !== "object") continue;
+      const content = (cand as Record<string, unknown>).content;
+      if (!content || typeof content !== "object") continue;
+      const parts = (content as Record<string, unknown>).parts;
+      if (Array.isArray(parts)) {
+        for (const part of parts) {
+          if (!part || typeof part !== "object") continue;
+          const p = part as Record<string, unknown>;
+          if (p.functionCall && typeof (p.functionCall as Record<string, unknown>).name === "string") {
+            const fnCall = p.functionCall as Record<string, unknown>;
+            fnCall.name = toolMapper.fromGemini(fnCall.name as string);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Introduces bidirectional tool name mapping for Gemini API schemas to prevent validation errors and naming conflicts when tools use hyphens or other non-standard identifier characters.
- Sanitizes function declarations, configs, tool calls, and function responses before sending requests to the Gemini API.
- Restores original tool names in both non-streaming and streaming SSE response chunks so agent frameworks can resolve tool handlers properly.

## Rationale
Gemini API tool schemas enforce identifier names matching `^[a-zA-Z_][a-zA-Z0-9_]*$`. Many MCP servers and agent framework plugins define tool names containing hyphens, colons, or dots. Maintaining a session-aware two-way registry ensures compliance while preventing dispatch failures across multi-turn tool loops.