### PR TITLE
feat(retry): wait for quota reset on exhaustion

### DIFF
--- a/src/sdk/retry/index.ts
+++ b/src/sdk/retry/index.ts
@@ -7,7 +7,12 @@ import {
   resolveRetryDelayMs,
   wait,
 } from "./helpers";
-import { classifyQuotaResponse, retryInternals } from "./quota";
+import {
+  classifyQuotaResponse,
+  MAX_QUOTA_RESET_WAIT_MS,
+  resolveQuotaResetDelay,
+  retryInternals,
+} from "./quota";
 import { agyFetch } from "../../fetch";
 import { CooldownStore, loadCooldowns } from "./cooldown-store";
 
@@ -53,6 +58,7 @@ export async function fetchWithRetry(
   const throttleKey = buildRetryThrottleKey(input, retryInit);
   await waitForRetryCooldown(throttleKey, retryInit.signal);
   let attempt = 1;
+  let hasRetriedQuotaReset = false;
   const url = readRequestUrl(input);
 
   while (attempt <= DEFAULT_MAX_ATTEMPTS) {
@@ -82,7 +88,29 @@ export async function fetchWithRetry(
       if (quotaContext.reason === "MODEL_CAPACITY_EXHAUSTED") {
         const cooldownMs = quotaContext.retryDelayMs ?? MODEL_CAPACITY_COOLDOWN_MS;
         setRetryCooldown(throttleKey, cooldownMs);
+        return response;
       }
+
+      if (quotaContext.reason === "QUOTA_EXHAUSTED" && !hasRetriedQuotaReset && !retryInit.signal?.aborted) {
+        const body = typeof retryInit.body === "string" ? safeParseBody(retryInit.body) : null;
+        const project = readString(body?.project);
+        const model = readString(body?.model);
+        const token = extractAuthToken(retryInit.headers);
+
+        if (token && project) {
+          const resetInfo = await resolveQuotaResetDelay(token, project, model);
+          if (resetInfo && resetInfo.waitMs > 0 && resetInfo.waitMs <= MAX_QUOTA_RESET_WAIT_MS) {
+            hasRetriedQuotaReset = true;
+            setRetryCooldown(throttleKey, resetInfo.waitMs);
+            await wait(resetInfo.waitMs);
+            if (retryInit.signal?.aborted) {
+              return response;
+            }
+            continue;
+          }
+        }
+      }
+
       return response;
     }
 
@@ -185,6 +213,15 @@ function safeParseBody(body: string): Record<string, unknown> | null {
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function extractAuthToken(headers?: HeadersInit): string | undefined {
+  if (!headers) return undefined;
+  const h = new Headers(headers);
+  const auth = h.get("authorization") || h.get("Authorization");
+  if (!auth) return undefined;
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || auth.trim();
 }
 
 export { retryInternals };

--- a/src/sdk/retry/quota.ts
+++ b/src/sdk/retry/quota.ts
@@ -1,3 +1,6 @@
+import { retrieveUserQuotaSummary } from "../fetch_quota";
+import type { QuotaSummaryBucket, RetrieveUserQuotaSummaryResponse } from "../../plugin/project/types";
+
 interface GoogleRpcErrorInfo {
   "@type"?: string;
   reason?: string;
@@ -223,7 +226,96 @@ function normalizeErrorEnvelope(parsed: unknown): Record<string, unknown> | null
   return isObject(parsed) ? parsed : null;
 }
 
+export const MAX_QUOTA_RESET_WAIT_MS = 7_200_000; // 7200 seconds (2 hours)
+
+export function findResetTimeForModel(
+  summary: RetrieveUserQuotaSummaryResponse | null | undefined,
+  model?: string,
+): string | null {
+  if (!summary) return null;
+
+  const normalize = (str: string) => str.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const modelNorm = model ? normalize(model) : "";
+
+  let targetGroups = summary.groups ?? [];
+  if (modelNorm && targetGroups.length > 0) {
+    const matched = targetGroups.filter((g) => {
+      const gName = normalize(g.displayName ?? "");
+      return gName.includes(modelNorm) || modelNorm.includes(gName);
+    });
+    if (matched.length > 0) {
+      targetGroups = matched;
+    }
+  }
+
+  const allBuckets: QuotaSummaryBucket[] = [];
+  for (const group of targetGroups) {
+    if (group.buckets) {
+      allBuckets.push(...group.buckets);
+    }
+  }
+  if (allBuckets.length === 0 && summary.buckets) {
+    allBuckets.push(...summary.buckets);
+  }
+
+  const now = Date.now();
+  const validResetBuckets = allBuckets.filter((b) => {
+    if (!b.resetTime) return false;
+    const t = new Date(b.resetTime).getTime();
+    return !Number.isNaN(t) && t > now;
+  });
+
+  if (validResetBuckets.length === 0) {
+    return null;
+  }
+
+  const exhaustedFiveHour = validResetBuckets.find(
+    (b) => (b.remainingFraction === 0 || b.disabled) && b.window?.toUpperCase() === "FIVE_HOUR",
+  );
+  if (exhaustedFiveHour?.resetTime) return exhaustedFiveHour.resetTime;
+
+  const exhaustedAny = validResetBuckets.find((b) => b.remainingFraction === 0 || b.disabled);
+  if (exhaustedAny?.resetTime) return exhaustedAny.resetTime;
+
+  const fiveHour = validResetBuckets.find((b) => b.window?.toUpperCase() === "FIVE_HOUR");
+  if (fiveHour?.resetTime) return fiveHour.resetTime;
+
+  validResetBuckets.sort(
+    (a, b) => new Date(a.resetTime!).getTime() - new Date(b.resetTime!).getTime(),
+  );
+  return validResetBuckets[0]?.resetTime ?? null;
+}
+
+export async function resolveQuotaResetDelay(
+  accessToken: string,
+  projectId: string,
+  model?: string,
+  userAgentModel?: string,
+): Promise<{ waitMs: number; resetTime: string } | null> {
+  try {
+    const summary = await retrieveUserQuotaSummary(accessToken, projectId, userAgentModel);
+    if (!summary) return null;
+
+    const resetTime = findResetTimeForModel(summary, model);
+    if (!resetTime) return null;
+
+    const resetTimestamp = new Date(resetTime).getTime();
+    if (Number.isNaN(resetTimestamp)) return null;
+
+    const waitMs = resetTimestamp - Date.now() + 1000;
+    if (waitMs <= 0 || waitMs > MAX_QUOTA_RESET_WAIT_MS) {
+      return null;
+    }
+
+    return { waitMs, resetTime };
+  } catch {
+    return null;
+  }
+}
+
 export const retryInternals = {
   parseRetryDelayValue,
   parseRetryDelayFromMessage,
+  findResetTimeForModel,
+  resolveQuotaResetDelay,
 };

--- a/test/final-95-target-booster.test.ts
+++ b/test/final-95-target-booster.test.ts
@@ -13,7 +13,7 @@ describe('Final 95% Target Booster Suite', () => {
     const cache = new signatureCacheModule.SignatureCache({
       enabled: true,
       cache_file: tmpCache,
-      memory_ttl_seconds: 0.001, // 1ms TTL for instant expiry
+      memory_ttl_seconds: 0.05, // 50ms TTL
       disk_ttl_seconds: 3600,
       write_interval_seconds: 0.05
     });
@@ -22,7 +22,7 @@ describe('Final 95% Target Booster Suite', () => {
     expect(cache.has('expiring-key-1')).toBe(true);
 
     // Wait for memory TTL to expire
-    await new Promise(r => setTimeout(r, 20));
+    await new Promise(r => setTimeout(r, 70));
 
     // Call private cleanupExpired method via any
     (cache as any).cleanupExpired();

--- a/test/sdk-retry-quota.test.ts
+++ b/test/sdk-retry-quota.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from "vitest";
-import { classifyQuotaResponse, parseRetryDelayFromBody, retryInternals } from "../src/sdk/retry/quota";
+import { describe, it, expect, vi } from "vitest";
+import {
+  classifyQuotaResponse,
+  parseRetryDelayFromBody,
+  findResetTimeForModel,
+  resolveQuotaResetDelay,
+  MAX_QUOTA_RESET_WAIT_MS,
+  retryInternals,
+} from "../src/sdk/retry/quota";
+import * as fetchQuotaModule from "../src/sdk/fetch_quota";
+import type { RetrieveUserQuotaSummaryResponse } from "../src/plugin/project/types";
 
 describe("sdk/retry/quota", () => {
   it("parses retry delay values correctly", () => {
@@ -244,5 +253,137 @@ describe("sdk/retry/quota", () => {
       { status: 429 }
     );
     expect((await classifyQuotaResponse(resArrayEnvelope))?.reason).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
+  describe("findResetTimeForModel", () => {
+    it("returns null if summary is null or undefined", () => {
+      expect(findResetTimeForModel(null)).toBeNull();
+      expect(findResetTimeForModel(undefined)).toBeNull();
+    });
+
+    it("returns null if no buckets have future reset times", () => {
+      const pastSummary: RetrieveUserQuotaSummaryResponse = {
+        buckets: [
+          { resetTime: new Date(Date.now() - 100000).toISOString(), window: "FIVE_HOUR" },
+          { resetTime: "invalid-date", window: "FIVE_HOUR" },
+          { window: "FIVE_HOUR" },
+        ],
+      };
+      expect(findResetTimeForModel(pastSummary)).toBeNull();
+    });
+
+    it("prioritizes exhausted FIVE_HOUR bucket matching model", () => {
+      const futureReset = new Date(Date.now() + 300000).toISOString();
+      const futureOther = new Date(Date.now() + 600000).toISOString();
+      const summary: RetrieveUserQuotaSummaryResponse = {
+        groups: [
+          {
+            displayName: "Claude Opus 3.5",
+            buckets: [
+              { resetTime: futureOther, window: "FIVE_HOUR", remainingFraction: 1 },
+            ],
+          },
+          {
+            displayName: "Gemini 2.5 Pro",
+            buckets: [
+              { resetTime: futureReset, window: "FIVE_HOUR", remainingFraction: 0 },
+            ],
+          },
+        ],
+      };
+
+      expect(findResetTimeForModel(summary, "gemini-2.5-pro")).toBe(futureReset);
+    });
+
+    it("falls back to exhausted bucket if not FIVE_HOUR", () => {
+      const futureReset = new Date(Date.now() + 300000).toISOString();
+      const summary: RetrieveUserQuotaSummaryResponse = {
+        groups: [
+          {
+            displayName: "Gemini Flash",
+            buckets: [
+              { resetTime: futureReset, window: "WEEKLY", remainingFraction: 0, disabled: true },
+            ],
+          },
+        ],
+      };
+
+      expect(findResetTimeForModel(summary, "gemini-flash")).toBe(futureReset);
+    });
+
+    it("falls back to non-exhausted FIVE_HOUR bucket", () => {
+      const futureReset = new Date(Date.now() + 300000).toISOString();
+      const summary: RetrieveUserQuotaSummaryResponse = {
+        groups: [
+          {
+            displayName: "Default",
+            buckets: [
+              { resetTime: futureReset, window: "FIVE_HOUR", remainingFraction: 0.5 },
+            ],
+          },
+        ],
+      };
+
+      expect(findResetTimeForModel(summary)).toBe(futureReset);
+    });
+
+    it("falls back to earliest valid bucket when no FIVE_HOUR or exhausted buckets exist", () => {
+      const earlier = new Date(Date.now() + 100000).toISOString();
+      const later = new Date(Date.now() + 500000).toISOString();
+      const summary: RetrieveUserQuotaSummaryResponse = {
+        buckets: [
+          { resetTime: later, window: "DAILY", remainingFraction: 0.5 },
+          { resetTime: earlier, window: "DAILY", remainingFraction: 0.5 },
+        ],
+      };
+
+      expect(findResetTimeForModel(summary)).toBe(earlier);
+    });
+  });
+
+  describe("resolveQuotaResetDelay", () => {
+    it("returns waitMs and resetTime if within MAX_QUOTA_RESET_WAIT_MS", async () => {
+      const futureDate = new Date(Date.now() + 60000); // 60s
+      vi.spyOn(fetchQuotaModule, "retrieveUserQuotaSummary").mockResolvedValueOnce({
+        buckets: [
+          { resetTime: futureDate.toISOString(), window: "FIVE_HOUR", remainingFraction: 0 },
+        ],
+      });
+
+      const result = await resolveQuotaResetDelay("token", "proj", "gemini-pro");
+      expect(result).not.toBeNull();
+      expect(result?.resetTime).toBe(futureDate.toISOString());
+      expect(result?.waitMs).toBeGreaterThan(50000);
+      expect(result?.waitMs).toBeLessThanOrEqual(62000);
+    });
+
+    it("returns null if summary fetch returns null or throws", async () => {
+      vi.spyOn(fetchQuotaModule, "retrieveUserQuotaSummary").mockResolvedValueOnce(null);
+      expect(await resolveQuotaResetDelay("token", "proj")).toBeNull();
+
+      vi.spyOn(fetchQuotaModule, "retrieveUserQuotaSummary").mockRejectedValueOnce(new Error("network error"));
+      expect(await resolveQuotaResetDelay("token", "proj")).toBeNull();
+    });
+
+    it("returns null if waitMs exceeds MAX_QUOTA_RESET_WAIT_MS", async () => {
+      const farFuture = new Date(Date.now() + MAX_QUOTA_RESET_WAIT_MS + 100000);
+      vi.spyOn(fetchQuotaModule, "retrieveUserQuotaSummary").mockResolvedValueOnce({
+        buckets: [
+          { resetTime: farFuture.toISOString(), window: "FIVE_HOUR", remainingFraction: 0 },
+        ],
+      });
+
+      expect(await resolveQuotaResetDelay("token", "proj")).toBeNull();
+    });
+
+    it("returns null if resetTime is invalid or in the past", async () => {
+      vi.spyOn(fetchQuotaModule, "retrieveUserQuotaSummary").mockResolvedValueOnce({
+        buckets: [
+          { resetTime: "invalid-date", window: "FIVE_HOUR" },
+        ],
+      });
+
+      expect(await resolveQuotaResetDelay("token", "proj")).toBeNull();
+    });
   });
 });

--- a/test/sdk/retry-index-deep.test.ts
+++ b/test/sdk/retry-index-deep.test.ts
@@ -144,5 +144,144 @@ describe('retry index and error delay deep coverage', () => {
     it('handles shutdownRetryCooldowns gracefully', () => {
       expect(() => retryModule.shutdownRetryCooldowns()).not.toThrow();
     });
+
+    it('waits for quota reset and retries on 429 QUOTA_EXHAUSTED', async () => {
+      const waitSpy = vi.spyOn(helpersModule, 'wait').mockResolvedValue();
+      const quotaResetSpy = vi.spyOn(quotaModule, 'resolveQuotaResetDelay').mockResolvedValue({
+        waitMs: 5000,
+        resetTime: new Date(Date.now() + 5000).toISOString(),
+      });
+      const fetchSpy = vi.spyOn(fetchModule, 'agyFetch')
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          error: {
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                domain: 'cloudcode-pa.googleapis.com',
+                reason: 'QUOTA_EXHAUSTED',
+              },
+            ],
+          },
+        }), { status: 429 }))
+        .mockResolvedValueOnce(new Response('{"success":true}', { status: 200 }));
+
+      const res = await retryModule.fetchWithRetry('https://daily-cloudcode-pa.googleapis.com/v1internal:test-quota', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-token' },
+        body: JSON.stringify({ project: 'test-project', model: 'gemini-2.5-pro' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(quotaResetSpy).toHaveBeenCalledWith('test-token', 'test-project', 'gemini-2.5-pro');
+      expect(waitSpy).toHaveBeenCalledWith(5000);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('extracts headers from Headers instance or Request object during quota reset', async () => {
+      vi.spyOn(helpersModule, 'wait').mockResolvedValue();
+      const quotaResetSpy = vi.spyOn(quotaModule, 'resolveQuotaResetDelay').mockResolvedValue(null);
+      vi.spyOn(fetchModule, 'agyFetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          error: {
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                domain: 'cloudcode-pa.googleapis.com',
+                reason: 'QUOTA_EXHAUSTED',
+              },
+            ],
+          },
+        }), { status: 429 })
+      );
+
+      const headers = new Headers();
+      headers.set('authorization', 'Bearer header-inst-token');
+
+      const req = new Request('https://daily-cloudcode-pa.googleapis.com/v1internal:test-req', {
+        method: 'POST',
+        headers,
+      });
+
+      const res = await retryModule.fetchWithRetry(req, {
+        headers: [['authorization', 'Bearer array-token']],
+        body: JSON.stringify({ project: 'req-proj' }),
+      });
+
+      expect(res.status).toBe(429);
+      expect(quotaResetSpy).toHaveBeenCalled();
+    });
+
+    it('does not retry quota reset more than once', async () => {
+      vi.spyOn(helpersModule, 'wait').mockResolvedValue();
+      const quotaResetSpy = vi.spyOn(quotaModule, 'resolveQuotaResetDelay').mockResolvedValue({
+        waitMs: 2000,
+        resetTime: new Date(Date.now() + 2000).toISOString(),
+      });
+      vi.spyOn(fetchModule, 'agyFetch')
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          error: {
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                domain: 'cloudcode-pa.googleapis.com',
+                reason: 'QUOTA_EXHAUSTED',
+              },
+            ],
+          },
+        }), { status: 429 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({
+          error: {
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                domain: 'cloudcode-pa.googleapis.com',
+                reason: 'QUOTA_EXHAUSTED',
+              },
+            ],
+          },
+        }), { status: 429 }));
+
+      const res = await retryModule.fetchWithRetry('https://daily-cloudcode-pa.googleapis.com/v1internal:test-quota2', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: JSON.stringify({ project: 'proj' }),
+      });
+
+      expect(res.status).toBe(429);
+      expect(quotaResetSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 429 response if signal is aborted during quota reset wait', async () => {
+      const controller = new AbortController();
+      vi.spyOn(helpersModule, 'wait').mockImplementation(async () => {
+        controller.abort();
+      });
+      vi.spyOn(quotaModule, 'resolveQuotaResetDelay').mockResolvedValue({
+        waitMs: 10000,
+        resetTime: new Date(Date.now() + 10000).toISOString(),
+      });
+      vi.spyOn(fetchModule, 'agyFetch').mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          error: {
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                domain: 'cloudcode-pa.googleapis.com',
+                reason: 'QUOTA_EXHAUSTED',
+              },
+            ],
+          },
+        }), { status: 429 })
+      );
+
+      const res = await retryModule.fetchWithRetry('https://daily-cloudcode-pa.googleapis.com/v1internal:test-abort', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+        body: JSON.stringify({ project: 'proj' }),
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(429);
+    });
   });
 });


### PR DESCRIPTION
### Summary

- Retrieves quota summary on 429 quota exhaustion to determine the remaining duration until the 5-hour limit reset.
- Automatically waits and retries requests once if the reset occurs within the 7200s (2-hour) window.
- Fails fast with quota exhaustion details if the reset time exceeds the maximum wait limit or cannot be resolved.