### PR TITLE
fix(request): attach thoughtSignature to part instead of functionCall

### DIFF
--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -576,23 +576,30 @@ function injectMissingToolCallIds(contents: any[]): void {
 }
 
 function applyLatestSignature(contents: any[], latestSig: string | undefined): void {
-  // Collect all function calls in chronological order
-  const allFunctionCalls: any[] = [];
+  // Collect all function call parts in chronological order
+  const allFunctionParts: any[] = [];
   for (const content of contents) {
     if (content && typeof content === "object" && Array.isArray(content.parts)) {
       for (const part of content.parts) {
         if (part && typeof part === "object" && part.functionCall) {
-          allFunctionCalls.push(part.functionCall);
+          // If thoughtSignature was mistakenly placed inside functionCall, migrate or clean it up
+          if (part.functionCall.thoughtSignature) {
+            if (!part.thoughtSignature || part.thoughtSignature === "skip_thought_signature_validator") {
+              part.thoughtSignature = part.functionCall.thoughtSignature;
+            }
+            delete part.functionCall.thoughtSignature;
+          }
+          allFunctionParts.push(part);
         }
       }
     }
   }
 
-  // Only apply the latest signature to the VERY LAST function call
-  if (allFunctionCalls.length > 0 && latestSig) {
-    const lastFunctionCall = allFunctionCalls[allFunctionCalls.length - 1];
-    if (!lastFunctionCall.thoughtSignature || lastFunctionCall.thoughtSignature === "skip_thought_signature_validator") {
-      lastFunctionCall.thoughtSignature = latestSig;
+  // Only apply the latest signature to the VERY LAST function call part
+  if (allFunctionParts.length > 0 && latestSig) {
+    const lastPart = allFunctionParts[allFunctionParts.length - 1];
+    if (!lastPart.thoughtSignature || lastPart.thoughtSignature === "skip_thought_signature_validator") {
+      lastPart.thoughtSignature = latestSig;
     }
   }
 }

--- a/test/prepare-request.test.ts
+++ b/test/prepare-request.test.ts
@@ -290,10 +290,10 @@ describe("prepareAgyRequest Comprehensive Suite", () => {
           role: "model",
           parts: [
             {
+              thoughtSignature: "skip_thought_signature_validator",
               functionCall: {
                 id: "call-1",
                 name: "toolA",
-                thoughtSignature: "skip_thought_signature_validator",
               },
             },
             {
@@ -310,7 +310,41 @@ describe("prepareAgyRequest Comprehensive Suite", () => {
     const result = prepareAgyRequest(input, { method: "POST", body }, token, project);
     const parsed = JSON.parse(result.init.body as string);
     const parts = parsed.request.contents[0].parts;
-    expect(parts[1].functionCall.thoughtSignature).toBe(sig);
+    expect(parts[1].thoughtSignature).toBe(sig);
+    expect(parts[1].functionCall.thoughtSignature).toBeUndefined();
+    expect(parts[0].thoughtSignature).toBe("skip_thought_signature_validator");
+    expect(parts[0].functionCall.thoughtSignature).toBeUndefined();
+  });
+
+  it("migrates thoughtSignature if mistakenly placed in functionCall", () => {
+    const sessionId = "session-migrate-test";
+    const sig = "migrated-sig-123";
+    cacheSignature(sessionId, "thought-text", sig);
+
+    const input = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent";
+    const body = JSON.stringify({
+      sessionId: sessionId,
+      contents: [
+        {
+          role: "model",
+          parts: [
+            {
+              functionCall: {
+                id: "call-1",
+                name: "toolA",
+                thoughtSignature: "skip_thought_signature_validator",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = prepareAgyRequest(input, { method: "POST", body }, token, project);
+    const parsed = JSON.parse(result.init.body as string);
+    const parts = parsed.request.contents[0].parts;
+    expect(parts[0].thoughtSignature).toBe(sig);
+    expect(parts[0].functionCall.thoughtSignature).toBeUndefined();
   });
 
   it("recovers thinking when state tracker indicates in tool loop without thinking", () => {


### PR DESCRIPTION
### Summary

- Fixes protobuf schema validation errors (`Unknown name "thoughtSignature" at 'request.contents[...].parts[...].function_call'`) by ensuring `thoughtSignature` is placed on the `part` object instead of inside `functionCall`.
- Migrates any misplaced `thoughtSignature` properties found on `functionCall` back to the `part` level in `applyLatestSignature`.