### PR TITLE
feat(sdk): bump agy cli to 1.1.20

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.19"
+      "release-as": "1.1.20"
     }
   },
   "changelog-types": [

--- a/models.json
+++ b/models.json
@@ -42,7 +42,7 @@
     }
   },
   "experimentIds": [
-    106140402,
+    106581054,
     105979552,
     105979574,
     106015333,
@@ -50,7 +50,6 @@
     105867471,
     106548982,
     106123599,
-    106076629,
     106121401,
     106100625,
     106143956,
@@ -61,7 +60,6 @@
     106567313,
     106396310,
     106470335,
-    105757908,
     106106760,
     106021688,
     105887299,
@@ -150,7 +148,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-23T17:45:20Z"
+        "resetTime": "2026-08-25T09:18:20Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -186,7 +184,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-23T17:45:20Z"
+        "resetTime": "2026-08-25T09:18:20Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -218,8 +216,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -237,8 +235,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -256,8 +254,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       }
     },
     "gemini-2.5-pro": {
@@ -276,8 +274,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -351,8 +349,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -426,8 +424,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -490,8 +488,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -509,8 +507,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -538,8 +536,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -620,8 +618,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -695,8 +693,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -772,8 +770,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -858,8 +856,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -944,8 +942,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1030,8 +1028,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1115,8 +1113,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1193,8 +1191,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1273,8 +1271,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1353,8 +1351,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1432,8 +1430,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1513,8 +1511,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9378517,
-        "resetTime": "2026-08-23T17:21:50Z"
+        "remainingFraction": 0.9598632,
+        "resetTime": "2026-08-25T09:13:21Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1585,7 +1583,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-23T17:45:20Z"
+        "resetTime": "2026-08-25T09:18:20Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.1.19",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/google": "^4.0.50",
+        "@ai-sdk/google": "^4.0.51",
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.18.21"
+        "@opencode-ai/plugin": "^1.18.22"
       },
       "devDependencies": {
-        "@opencode-ai/sdk": "^1.18.21",
-        "@types/node": "^26.2.0",
+        "@opencode-ai/sdk": "^1.18.22",
+        "@types/node": "^26.3.0",
         "@vitest/coverage-v8": "^4.1.11",
         "tsup": "^8.5.1",
         "typescript": "^7.0.2",
@@ -23,13 +23,13 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "4.0.50",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.50.tgz",
-      "integrity": "sha512-n7aMmqw6ZGVNBDAiv89fZkuZp3ahfzwZTXsdW27WugXdFSIuLTlYBZ+FlKGRdk1pRMPrdIGT2GPL2Ra0Gc2Tkg==",
+      "version": "4.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.51.tgz",
+      "integrity": "sha512-VAVXFtmMwrMDWgWzONew3yBFuE+ktfPJQn554+bOgUspNSMqIAm6PJRU6Mdd4M+4xCUAJi5H5tVtFF0+Je+Eog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.7",
-        "@ai-sdk/provider-utils": "5.0.29"
+        "@ai-sdk/provider": "4.0.8",
+        "@ai-sdk/provider-utils": "5.0.30"
       },
       "engines": {
         "node": ">=22"
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
-      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.8.tgz",
+      "integrity": "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -63,12 +63,12 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.29",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.29.tgz",
-      "integrity": "sha512-7EIbwXiXKGa7EFk6tDZpuZBs6lxhEJpOuHeqrDb3Vd85uYdjwkdRuHnZDVDIIb2+QTSRmyph2NrXcbvuO/KAjQ==",
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.30.tgz",
+      "integrity": "sha512-9TyxUXolql77ntHIeygLqt7PO1O0HZPB73cJhLG2OsPecSBRIZhNXLxT1T7rlL6Zpm1eDoLMFrMV99kAJ28/Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider": "4.0.8",
         "@standard-schema/spec": "^1.1.0",
         "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8",
@@ -82,9 +82,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
-      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.8.tgz",
+      "integrity": "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -733,13 +733,13 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.21",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.21.tgz",
-      "integrity": "sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg==",
+      "version": "1.18.22",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.22.tgz",
+      "integrity": "sha512-ExKQu8EkJRZgPzKIEiYvLuTs/wYsOxDFerjwHG7pJJhOeXqNOuPYLzuU4w3cpzMZp5vu7q2larJ/+K6M4ax2Xw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.21",
+        "@opencode-ai/sdk": "1.18.22",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.21",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.21.tgz",
-      "integrity": "sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA==",
+      "version": "1.18.22",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.22.tgz",
+      "integrity": "sha512-fRZ2r6nqdLBXfs7j531aibrqCC9tpbL2tmz3ThnwtLa3bMNUozEVAOPnZjh86JcTBDhNtACt5CNgKDZ1Pve1NA==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1515,9 +1515,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@opencode-ai/sdk": "^1.18.21",
-    "@types/node": "^26.2.0",
+    "@opencode-ai/sdk": "^1.18.22",
+    "@types/node": "^26.3.0",
     "@vitest/coverage-v8": "^4.1.11",
     "tsup": "^8.5.1",
     "typescript": "^7.0.2",
     "vitest": "^4.1.11"
   },
   "dependencies": {
-    "@ai-sdk/google": "^4.0.50",
+    "@ai-sdk/google": "^4.0.51",
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.18.21"
+    "@opencode-ai/plugin": "^1.18.22"
   }
 }

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.19';
+const AGY_API_VERSION = '1.1.20';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.19';
+export const AGY_CLI_VERSION = '1.1.20';

--- a/test/plugin/provider.test.ts
+++ b/test/plugin/provider.test.ts
@@ -37,7 +37,7 @@ describe('provider helpers', () => {
       })
     ).toBe('p-env');
 
-    expect(resolveConfiguredProjectId()).toBeUndefined();
+    expect(resolveConfiguredProjectId({ env: {} })).toBeUndefined();
   });
 
   it('resolves configured project ID from client', async () => {


### PR DESCRIPTION
# Description

### SDK CLI Version
Update `AGY_CLI_VERSION` to `1.1.20` in `src/sdk/agy-cli-version.ts` and `scripts/fetch-models.mjs`.
Ensure API User-Agent attribution and model synchronization match the upstream release.

### Release Configuration
Update `.release-please-config.json` release target to `1.1.20`.
Align release-please version tagging with current CLI baseline.

### Dependencies & Models Catalog
Bump `@opencode-ai/plugin`, `@opencode-ai/sdk`, `@ai-sdk/google`, and `@types/node` to latest semver releases.
Refresh internal models catalog from the live Code Assist endpoint while preserving model deprecation mappings.