### PR TITLE
feat(sdk): bump agy cli to 1.1.21

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.20"
+      "release-as": "1.1.21"
     }
   },
   "changelog-types": [

--- a/models.json
+++ b/models.json
@@ -148,7 +148,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-25T09:18:20Z"
+        "resetTime": "2026-08-26T11:05:27Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -184,7 +184,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-25T09:18:20Z"
+        "resetTime": "2026-08-26T11:05:27Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -216,8 +216,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -235,8 +235,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -254,8 +254,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       }
     },
     "gemini-2.5-pro": {
@@ -274,8 +274,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -349,8 +349,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -424,8 +424,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -488,8 +488,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -507,8 +507,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -536,8 +536,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -618,8 +618,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -693,8 +693,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -770,8 +770,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -856,8 +856,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -942,8 +942,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1028,8 +1028,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1113,8 +1113,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1191,8 +1191,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1271,8 +1271,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1351,8 +1351,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1430,8 +1430,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1511,8 +1511,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9598632,
-        "resetTime": "2026-08-25T09:13:21Z"
+        "remainingFraction": 0.9828337,
+        "resetTime": "2026-08-26T10:58:56Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1583,7 +1583,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-25T09:18:20Z"
+        "resetTime": "2026-08-26T11:05:27Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@ai-sdk/google": "^4.0.51",
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.18.22"
+        "@opencode-ai/plugin": "^1.18.23"
       },
       "devDependencies": {
-        "@opencode-ai/sdk": "^1.18.22",
+        "@opencode-ai/sdk": "^1.18.23",
         "@types/node": "^26.3.0",
         "@vitest/coverage-v8": "^4.1.11",
         "tsup": "^8.5.1",
@@ -733,13 +733,13 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.22",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.22.tgz",
-      "integrity": "sha512-ExKQu8EkJRZgPzKIEiYvLuTs/wYsOxDFerjwHG7pJJhOeXqNOuPYLzuU4w3cpzMZp5vu7q2larJ/+K6M4ax2Xw==",
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.23.tgz",
+      "integrity": "sha512-a+LbJe+wyyiwOQ7DeYOY4MkI/6VL45wkgYunVNZGC93UQgaj6sMGemS45CsLXrjyF4bvJMtqGd66GJvgjzbXAg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.22",
+        "@opencode-ai/sdk": "1.18.23",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.22",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.22.tgz",
-      "integrity": "sha512-fRZ2r6nqdLBXfs7j531aibrqCC9tpbL2tmz3ThnwtLa3bMNUozEVAOPnZjh86JcTBDhNtACt5CNgKDZ1Pve1NA==",
+      "version": "1.18.23",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.23.tgz",
+      "integrity": "sha512-VouYbL8O2ynLq0atr5fjzCv8YLtFi/zKLQ/uYkCvTJ4CmUdA01XwPn8om+u3TvxnGEfQsBfmThGU141vt3sg5w==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@opencode-ai/sdk": "^1.18.22",
+    "@opencode-ai/sdk": "^1.18.23",
     "@types/node": "^26.3.0",
     "@vitest/coverage-v8": "^4.1.11",
     "tsup": "^8.5.1",
@@ -39,6 +39,6 @@
   "dependencies": {
     "@ai-sdk/google": "^4.0.51",
     "@openauthjs/openauth": "^0.4.3",
-    "@opencode-ai/plugin": "^1.18.22"
+    "@opencode-ai/plugin": "^1.18.23"
   }
 }

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.20';
+const AGY_API_VERSION = '1.1.21';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.20';
+export const AGY_CLI_VERSION = '1.1.21';


### PR DESCRIPTION
# Description

### SDK CLI Version
Update `AGY_CLI_VERSION` to `1.1.21` in `src/sdk/agy-cli-version.ts` and `scripts/fetch-models.mjs`.
Ensure API User-Agent attribution and model synchronization match the upstream release.

### Release Configuration
Update `.release-please-config.json` release target to `1.1.21`.
Align release-please version tagging with current CLI baseline.

### Dependencies & Models Catalog
Bump `@opencode-ai/plugin` and `@opencode-ai/sdk` to `1.18.23`.
Refresh internal models catalog from the live Code Assist endpoint while preserving model deprecation mappings.