### PR TITLE
feat(sdk): bump agy cli to 1.1.22

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.21"
+      "release-as": "1.1.22"
     }
   },
   "changelog-types": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,22 @@ OpenCode plugin that adds the Google Gemini Antigravity CLI (`agy`) OAuth provid
 
 ## agy CLI bump workflow
 
-When a new `agy` CLI release lands (check `https://github.com/google-antigravity/antigravity-cli/releases`):
+When a new `agy` CLI release lands (check `https://github.com/google-antigravity/antigravity-cli/releases`), execute every step in sequence without skipping.
 
-1. Install or upgrade the CLI locally so `agy --version` matches the target release.
-2. Read the release notes and changelog at `https://github.com/google-antigravity/antigravity-cli/releases/tag/<VERSION>` (note: the tag is `<version>` without the "v" prefix, e.g. `0.1.2`, not `v0.1.2`):
-   - **Audit changelog for plugin improvements**: Identify upstream bug fixes, protocol changes, new request parameters, error handling adjustments, or server-side capabilities that can be ported or integrated into this plugin.
-   - **Inspect local agy binary**: GitHub releases primarily track client UX. Use `strings` on the installed `antigravity` binary to discover internal RPC routes, header adjustments, or payload changes (`strings $(readlink -f $(which agy)) | grep -E 'v1internal|daily-cloudcode|CodeAssist'`). Diffing binary strings against the previous installed version reveals unannounced backend protocol changes.
-   - **Inspect server response payloads & error structures**: Check live HTTP error payloads and retry headers (`retry-after-ms`, `error.details[]` structures like `type.googleapis.com/google.rpc.RetryInfo` or `QuotaFailure`) to adjust plugin parsing or retry strategies when upstream error shapes evolve.
-   - **Report analysis findings**: Explain whether actionable features or bug fixes exist to implement in this plugin, or clearly state that none apply (e.g., client-only changes).
-   - **Implement relevant changes**: If actionable fixes or features are found, implement and test them alongside the version bump.
-   - **Reconcile surface**: Most agy CLI releases are client-only UI/UX work (Vim mode, artifact rendering, terminal hyperlinks) or local filesystem fixes (atomic config writes, keyring timeouts) that require no plugin change, but always audit backend/protocol additions.
-3. Update `src/sdk/agy-cli-version.ts` and `scripts/fetch-models.mjs` (`AGY_API_VERSION`) to the new version. This constant feeds `buildAgyCliUserAgent()` in `src/sdk/user-agent.ts` and `scripts/fetch-models.mjs`, setting the `User-Agent` header on every Code Assist API request. Aligning it with the installed CLI keeps server-side attribution consistent.
-4. Update `.release-please-config.json` (`"release-as"` field) to the new version. Do **not** touch `.release-please-manifest.json`; release-please manages it automatically on PR merge. Note: `package.json` version bumps are handled by Renovate / release-please automatically.
-5. Run `npm outdated` and bump dependencies to latest semver-compatible. `@ai-sdk/google` is never imported by the plugin; it is only referenced as a literal npm-name string in `src/plugin.ts:179` and `src/plugin.ts:438`, so version bumps are zero-risk.
-6. Refresh `models.json` from a live `fetchAvailableModels` call (see below).
-7. Run `npm install && npm run test:coverage && npm run typecheck && npm run build && npm run smoke:node-import`.
+**CRITICAL MANDATE**: Always audit backend and protocol additions. Upstream release notes primarily highlight user-facing UI changes, but minor/patch releases frequently introduce unannounced backend protocol updates, internal RPC routes, header adjustments, or payload schema changes. Never assume a bump is client-only without performing the full binary and server inspection.
+
+1. **Install or upgrade CLI locally**: Ensure `agy --version` matches the target release.
+2. **Audit changelog & release notes**: Read `https://github.com/google-antigravity/antigravity-cli/releases/tag/<VERSION>` (note: tag is `<version>` without "v" prefix, e.g. `0.1.2`). Identify upstream bug fixes, protocol changes, new request parameters, error handling adjustments, or server-side capabilities.
+3. **Inspect local agy binary**: Run `strings $(readlink -f $(which agy)) | grep -E 'v1internal|daily-cloudcode|CodeAssist'` to discover internal RPC routes, header adjustments, or payload changes. Diffing binary strings against the previous version reveals unannounced backend protocol changes.
+4. **Inspect server response payloads & error structures**: Check live HTTP error payloads and retry headers (`retry-after-ms`, `error.details[]` structures like `type.googleapis.com/google.rpc.RetryInfo` or `QuotaFailure`). Test live quota calls with the `agy_quota` and `agy_quota_summary` tools to confirm server schema compatibility.
+5. **Reconcile against surface review checklist**: Systematically cross-reference the [Surface review checklist](#surface-review-checklist) to verify whether any plugin component requires updates for new capabilities, endpoints, or error codes.
+6. **Report analysis findings**: Explicitly report findings to the user. State clearly whether actionable features or protocol adjustments exist to implement, or confirm with evidence that all upstream changes are client-only (e.g. CLI UI, terminal rendering, keyring handling).
+7. **Implement relevant plugin adjustments**: If actionable backend fixes or protocol changes were discovered in steps 2-6, implement and test them before bumping constants.
+8. **Update version constants**: Update `src/sdk/agy-cli-version.ts` (`AGY_CLI_VERSION`) and `scripts/fetch-models.mjs` (`AGY_API_VERSION`) to the new version. This sets the `User-Agent` header on every Code Assist API request.
+9. **Update release config**: Update `.release-please-config.json` (`"release-as"` field) to the new version. Do **not** touch `.release-please-manifest.json`; release-please manages it automatically on PR merge.
+10. **Check dependencies**: Run `npm outdated` and bump dependencies to latest semver-compatible. (`@ai-sdk/google` is only a literal string reference in `src/plugin.ts`, so version bumps are zero-risk).
+11. **Refresh model catalog**: Run `npm run models:refresh` and verify diff (see [Refreshing models.json](#refreshing-modelsjson)).
+12. **Run full verification suite**: Execute `npm install && npm run test:coverage && npm run typecheck && npm run build && npm run smoke:node-import`. All tests and quality gates must pass cleanly.
 
 Prior bump commits follow a consistent pattern. Run `git log --oneline | grep "bump agy cli"` for examples.
 

--- a/models.json
+++ b/models.json
@@ -42,7 +42,7 @@
     }
   },
   "experimentIds": [
-    106581054,
+    106140402,
     105979552,
     105979574,
     106015333,
@@ -148,7 +148,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-26T11:05:27Z"
+        "resetTime": "2026-08-27T09:40:24Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -184,7 +184,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-26T11:05:27Z"
+        "resetTime": "2026-08-27T09:40:24Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -216,8 +216,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -235,8 +235,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -254,8 +254,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       }
     },
     "gemini-2.5-pro": {
@@ -274,8 +274,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -349,8 +349,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -424,8 +424,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -488,8 +488,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -507,8 +507,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -536,8 +536,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -618,8 +618,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -693,8 +693,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -770,8 +770,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -856,8 +856,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -942,8 +942,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1028,8 +1028,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1113,8 +1113,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1191,8 +1191,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1271,8 +1271,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1351,8 +1351,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1430,8 +1430,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1511,8 +1511,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9828337,
-        "resetTime": "2026-08-26T10:58:56Z"
+        "remainingFraction": 0.9854128,
+        "resetTime": "2026-08-27T09:38:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1583,7 +1583,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-08-26T11:05:27Z"
+        "resetTime": "2026-08-27T09:40:24Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.21';
+const AGY_API_VERSION = '1.1.22';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.21';
+export const AGY_CLI_VERSION = '1.1.22';


### PR DESCRIPTION
# Description

### SDK Versioning & Release
Bump Antigravity CLI version constants to 1.1.22 in `src/sdk/agy-cli-version.ts`, `scripts/fetch-models.mjs`, and `.release-please-config.json`.
Synchronize User-Agent header and release automation with the upstream 1.1.22 release.

### Model Catalog
Refresh internal server model catalog in `models.json`.
Ensure live model availability matches the updated Code Assist backend definitions and preserve fallback mappings.

### Workflow & Documentation
Reinforce the agy CLI bump workflow documentation in `AGENTS.md`.
Mandate explicit inspection of local binary strings, RPC routes, server response payloads, and quota structures during version upgrades.
