### PR TITLE
feat(sdk): bump agy cli to 1.1.25

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.24"
+      "release-as": "1.1.25"
     }
   },
   "changelog-types": [

--- a/models.json
+++ b/models.json
@@ -152,7 +152,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-03T01:15:50Z"
+        "resetTime": "2026-09-03T08:51:40Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -191,7 +191,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-03T01:15:50Z"
+        "resetTime": "2026-09-03T08:51:40Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -223,8 +223,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -242,8 +242,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -261,8 +261,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       }
     },
     "gemini-2.5-pro": {
@@ -281,8 +281,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -356,8 +356,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -431,8 +431,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -495,8 +495,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -514,8 +514,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -546,8 +546,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -631,8 +631,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -706,8 +706,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -783,8 +783,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -872,8 +872,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -961,8 +961,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1050,8 +1050,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1138,8 +1138,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1219,8 +1219,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1302,8 +1302,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1385,8 +1385,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1467,8 +1467,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1548,8 +1548,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1631,8 +1631,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1714,8 +1714,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1772,6 +1772,86 @@
       "tagTitle": "Fast",
       "thinkingBudget": 4000
     },
+    "gemini-3.8-flash-tiered": {
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "maxOutputTokens": 65536,
+      "maxTokens": 1048576,
+      "minThinkingBudget": 32,
+      "model": "MODEL_PLACEHOLDER_M322",
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SAME_MODEL\",\n    \"max_token_limit\": \"256000\",\n    \"token_threshold\": \"140000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": true,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    },\n    \"session_summary_prompt_override\": \"\"\n}"
+          },
+          "cascade-include-ephemeral-message": {
+            "stringValue": "{\n    \"enabled\": false,\n    \"disabledHeuristics\": [\"planning_mode\", \"bash_command_reminder\", \"running_tasks_reminder\"],\n    \"staticMessages\": [],\n    \"useAllowlist\": false,\n    \"enabledHeuristics\": []\n}"
+          },
+          "retry_model_capacity_exhausted": {
+            "boolValue": true
+          },
+          "task-details-suffix": {
+            "stringValue": "\nYOU MUST TAKE ONE OF THE FOLLOWING TWO ACTIONS: A) either proceed to other relevant work (if any) or, B) simply update the user with a short message (that you have launched the command and will wait for it to finish) and end the turn.\n DO NOTHING ELSE."
+          }
+        }
+      },
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "quotaInfo": {
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
+      },
+      "recommended": true,
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/pdf": true,
+        "application/rtf": true,
+        "application/x-ipynb+json": true,
+        "application/x-javascript": true,
+        "application/x-python-code": true,
+        "application/x-typescript": true,
+        "audio/aac": true,
+        "audio/flac": true,
+        "audio/l16": true,
+        "audio/m4a": true,
+        "audio/mp3": true,
+        "audio/mp4": true,
+        "audio/mpeg": true,
+        "audio/ogg": true,
+        "audio/opus": true,
+        "audio/vnd.wave": true,
+        "audio/wav": true,
+        "audio/wave": true,
+        "audio/webm": true,
+        "audio/webm;codecs=opus": true,
+        "audio/x-wav": true,
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "text/css": true,
+        "text/csv": true,
+        "text/html": true,
+        "text/javascript": true,
+        "text/markdown": true,
+        "text/plain": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "text/xml": true,
+        "video/audio/s16le": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "video/mp4": true,
+        "video/text/timestamp": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true
+      },
+      "supportsImages": true,
+      "supportsThinking": true,
+      "supportsVideo": true,
+      "thinkingBudget": -1
+    },
     "gemini-pro-agent": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "displayName": "Gemini 3.1 Pro (High)",
@@ -1800,8 +1880,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9912594,
-        "resetTime": "2026-09-03T00:54:32Z"
+        "remainingFraction": 0.9910493,
+        "resetTime": "2026-09-03T08:51:13Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1872,7 +1952,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-03T01:15:50Z"
+        "resetTime": "2026-09-03T08:51:40Z"
       },
       "recommended": true,
       "supportsThinking": true,
@@ -1920,7 +2000,7 @@
   ],
   "tieredModelIds": {
     "flash": [
-      "gemini-3.7-flash-tiered"
+      "gemini-3.8-flash-tiered"
     ],
     "flashLite": [
       "gemini-3.1-flash-lite"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "4.0.62",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.62.tgz",
-      "integrity": "sha512-DB8i10h9S3ki9b/bPz51B9f9Uy8/5vLfyYsyHuRgHDraro1TM+eqo6RqErZ5RA3smZZ5uFcNzK43ks07qr7vrA==",
+      "version": "4.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.63.tgz",
+      "integrity": "sha512-SlKcqnN0oKC8JWahecs3IvFnIFgbrEE4i/bmom5xsPFUjkIVvXAJAhRzjfgfROSOOeyvouKUFPWJEjn11FWf3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.10",
@@ -729,13 +729,13 @@
       "license": "MIT"
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.26",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.26.tgz",
-      "integrity": "sha512-frk7el3wQnIjoJ9ESuuS+wEhZ7wLz73enReuJ8ynRAf3akKtwy/DA7MxjUXhG2se5y9nXbypn3FJLkvm3RR2Lw==",
+      "version": "1.18.27",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.27.tgz",
+      "integrity": "sha512-/sQbDUVz/VlfTPjEEQ+fZ70Z9AwtVVwOMKYuGEjjSOpRvlQEC16+jnC3GO4w05VeyffAlghDbM/3p38fMEAhfw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.26",
+        "@opencode-ai/sdk": "1.18.27",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.26",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.26.tgz",
-      "integrity": "sha512-1TnlEZty7V2NTIZHbJOt2O+v6YsJ/Bt2pSYgXb98G/RkSVOjlDd/35+ewfYtM4fmMroaa6cEG6S58FihKO4K0w==",
+      "version": "1.18.27",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.27.tgz",
+      "integrity": "sha512-VTfAB9SWaGiMtI2L9rf2xl+0fTYDMHB2pHYKCquWG5OIX3rHvth9oM915d9Z38IuPZUZkmdNMVz2iAdxG4IR+A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.24';
+const AGY_API_VERSION = '1.1.25';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.24';
+export const AGY_CLI_VERSION = '1.1.25';


### PR DESCRIPTION
# Description

### CLI & API Version Pins
Bump agy CLI version constant to 1.1.25 across SDK and tooling.
Synchronize Code Assist User-Agent header and API query targets with upstream release.

### Release Configuration & Dependencies
Update release-please configuration target to 1.1.25.
Upgrade compatible workspace dependencies including @ai-sdk/google and OpenCode plugin packages.

### Model Catalog
Refresh internal models catalog to capture latest upstream tiered Flash model pointers and definitions.
Ensure model enum mappings resolve accurately against live server metadata.
