### PR TITLE
chore(release): configure github changelog generator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+---
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]
+      - renovate[bot]
+  categories:
+    - title: Features
+      labels:
+        - feature
+        - enhancement
+        - feat
+    - title: Bug Fixes
+      labels:
+        - fix
+        - bug
+    - title: Performance Improvements
+      labels:
+        - perf
+        - performance
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Documentation
+      labels:
+        - docs
+        - documentation
+    - title: Tests & Build
+      labels:
+        - test
+        - build
+        - ci
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,6 +7,7 @@
       "prerelease": false,
       "prerelease-type": "alpha",
       "changelog-path": "CHANGELOG.md",
+      "changelog-type": "github",
       "skip-github-release": false,
       "include-v-in-tag": false,
       "release-as": "1.1.25"


### PR DESCRIPTION
# Description

### Release Configuration
Switch release-please package changelog generator to github mode.
Allow commit and PR entries to format via native GitHub release notes.

### GitHub Release Template
Add release template with categorized sections and dependency bot exclusions.
Ensure clean categorization for features, bug fixes, refactoring, and build automation.