### PR TITLE
ci(workflows): bump github actions and node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [24.x, 26.x]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
       - name: Detect release-triggering changes
@@ -73,7 +73,7 @@ jobs:
       tag_name: ${{ steps.release-please.outputs.tag_name }}
       prerelease: ${{ steps.release-please.outputs.prerelease }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release-please
         with:
           config-file: .release-please-config.json
@@ -84,12 +84,12 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: latest
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci


### PR DESCRIPTION
## Summary

### GitHub Actions Workflows
Upgrade actions/checkout and actions/setup-node to v7 across CI and release workflows.
Bump googleapis/release-please-action to v5.

### Node Runtime Matrix
Update CI matrix to test across Node versions 24.x and 26.x.
Configure npm publish release step to target latest Node runtime.
