### PR TITLE
feat(sdk): bump agy cli to 1.1.27

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.26"
+      "release-as": "1.1.27"
     }
   },
   "changelog-types": [

--- a/models.json
+++ b/models.json
@@ -67,8 +67,6 @@
     106278607,
     106538964,
     106512082,
-    106654026,
-    106654028,
     106380926,
     106281951,
     106264532,
@@ -152,7 +150,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-04T09:33:59Z"
+        "resetTime": "2026-09-05T15:39:57Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -191,7 +189,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-04T09:33:59Z"
+        "resetTime": "2026-09-05T15:39:57Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -223,8 +221,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -242,8 +240,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -261,8 +259,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       }
     },
     "gemini-2.5-pro": {
@@ -281,8 +279,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -356,8 +354,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -431,8 +429,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -495,8 +493,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -514,8 +512,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -546,8 +544,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -631,8 +629,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -706,8 +704,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -764,6 +762,28 @@
       "tagTitle": "Fast",
       "thinkingBudget": 1000
     },
+    "gemini-3.5-flash-lite": {
+      "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
+      "displayName": "Gemini 3.5 Flash Lite",
+      "maxOutputTokens": 65535,
+      "maxTokens": 1048576,
+      "model": "MODEL_PLACEHOLDER_M277",
+      "modelExperiments": {
+        "experiments": {
+          "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
+            "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    },\n    \"session_summary_prompt_override\": \"\"\n}"
+          },
+          "retry_model_capacity_exhausted": {
+            "boolValue": true
+          }
+        }
+      },
+      "modelProvider": "MODEL_PROVIDER_GOOGLE",
+      "quotaInfo": {
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
+      }
+    },
     "gemini-3.5-flash-low": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
       "displayName": "Gemini 3.5 Flash (Medium)",
@@ -783,8 +803,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -872,8 +892,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -961,8 +981,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1050,8 +1070,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1138,8 +1158,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1219,8 +1239,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1302,8 +1322,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1385,8 +1405,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1467,8 +1487,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1548,8 +1568,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1631,8 +1651,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1714,8 +1734,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1796,8 +1816,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1880,8 +1900,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9808376,
-        "resetTime": "2026-09-04T09:31:53Z"
+        "remainingFraction": 0.9715965,
+        "resetTime": "2026-09-05T15:37:39Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1952,7 +1972,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-04T09:33:59Z"
+        "resetTime": "2026-09-05T15:39:57Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "4.0.63",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.63.tgz",
-      "integrity": "sha512-SlKcqnN0oKC8JWahecs3IvFnIFgbrEE4i/bmom5xsPFUjkIVvXAJAhRzjfgfROSOOeyvouKUFPWJEjn11FWf3A==",
+      "version": "4.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.64.tgz",
+      "integrity": "sha512-D8+74xfXkzPi5qCe7iRzQRH/1WW805gBrXfwz7KKEBa0SMY2TENdsTrJnVqFZaT7UYow1Ls6qroaklLd9veU9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "4.0.10",
@@ -729,13 +729,13 @@
       "license": "MIT"
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.27",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.27.tgz",
-      "integrity": "sha512-/sQbDUVz/VlfTPjEEQ+fZ70Z9AwtVVwOMKYuGEjjSOpRvlQEC16+jnC3GO4w05VeyffAlghDbM/3p38fMEAhfw==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.29.tgz",
+      "integrity": "sha512-IhF83EU4I/ASgWwvm0FIh1O3a8ZVuCLqPrCbmSHdSYq7GHxIYe773i6dHqcbrzCzvlG/lP2H+dyTQ+xPAwFpbw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.27",
+        "@opencode-ai/sdk": "1.18.29",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.27",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.27.tgz",
-      "integrity": "sha512-VTfAB9SWaGiMtI2L9rf2xl+0fTYDMHB2pHYKCquWG5OIX3rHvth9oM915d9Z38IuPZUZkmdNMVz2iAdxG4IR+A==",
+      "version": "1.18.29",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.29.tgz",
+      "integrity": "sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.26';
+const AGY_API_VERSION = '1.1.27';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.26';
+export const AGY_CLI_VERSION = '1.1.27';

--- a/src/sdk/request/prepare.ts
+++ b/src/sdk/request/prepare.ts
@@ -279,7 +279,10 @@ function transformRequestBody(
 
     if (isImageGen) {
       wrappedBody.requestType = "image_gen";
-    } else if (effectiveModel.includes("gemini-3.1-flash-lite")) {
+    } else if (
+      effectiveModel.includes("gemini-3.5-flash-lite") ||
+      effectiveModel.includes("gemini-3.1-flash-lite")
+    ) {
       wrappedBody.requestType = "checkpoint";
     } else if (effectiveModel.includes("gemini-2.5-flash-lite")) {
       wrappedBody.requestType = "chat";

--- a/test/prepare-request.test.ts
+++ b/test/prepare-request.test.ts
@@ -68,6 +68,10 @@ describe("prepareAgyRequest Comprehensive Suite", () => {
         expectedType: "image_gen",
       },
       {
+        url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent",
+        expectedType: "checkpoint",
+      },
+      {
         url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent",
         expectedType: "checkpoint",
       },


### PR DESCRIPTION
# Description

### SDK Version Constants
Update upstream agy CLI version constants to 1.1.27.
Maintain accurate User-Agent reporting across Code Assist API requests.

### Request Classification
Route gemini-3.5-flash-lite requests to checkpoint request type alongside gemini-3.1-flash-lite.
Ensure single-prompt checkpointing payload structure matches server requirements.

### Model Catalog & Release Config
Refresh internal models catalog against live fetchAvailableModels endpoint.
Advance release-please package target to 1.1.27 and update dependencies.