### PR TITLE
feat(sdk): bump agy cli to 1.1.28

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.1.27"
+      "release-as": "1.1.28"
     }
   },
   "changelog-types": [

--- a/models.json
+++ b/models.json
@@ -42,7 +42,7 @@
     }
   },
   "experimentIds": [
-    106329235,
+    106329232,
     105979552,
     105979574,
     106015333,
@@ -57,7 +57,6 @@
     105856899,
     106064030,
     106567313,
-    106396310,
     106106760,
     106021688,
     105887299,
@@ -65,7 +64,6 @@
     106283618,
     106640126,
     106278607,
-    106538964,
     106512082,
     106380926,
     106281951,
@@ -84,7 +82,6 @@
     106100654,
     106064028,
     106567309,
-    106396304,
     105906495,
     106283614,
     106640124,
@@ -150,7 +147,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-05T15:39:57Z"
+        "resetTime": "2026-09-09T10:37:15Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -189,7 +186,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-05T15:39:57Z"
+        "resetTime": "2026-09-09T10:37:15Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -221,8 +218,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       }
     },
     "gemini-2.5-flash-lite": {
@@ -240,8 +237,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       }
     },
     "gemini-2.5-flash-thinking": {
@@ -259,8 +256,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       }
     },
     "gemini-2.5-pro": {
@@ -279,8 +276,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -354,8 +351,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -429,8 +426,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -493,8 +490,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -512,8 +509,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -544,8 +541,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -629,8 +626,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -704,8 +701,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -767,7 +764,8 @@
       "displayName": "Gemini 3.5 Flash Lite",
       "maxOutputTokens": 65535,
       "maxTokens": 1048576,
-      "model": "MODEL_PLACEHOLDER_M277",
+      "minThinkingBudget": 128,
+      "model": "MODEL_PLACEHOLDER_M198",
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
@@ -780,9 +778,63 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
-      }
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
+      },
+      "recommended": true,
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/pdf": true,
+        "application/rtf": true,
+        "application/x-ipynb+json": true,
+        "application/x-javascript": true,
+        "application/x-python-code": true,
+        "application/x-typescript": true,
+        "audio/aac": true,
+        "audio/flac": true,
+        "audio/l16": true,
+        "audio/m4a": true,
+        "audio/mp3": true,
+        "audio/mp4": true,
+        "audio/mpeg": true,
+        "audio/ogg": true,
+        "audio/opus": true,
+        "audio/vnd.wave": true,
+        "audio/wav": true,
+        "audio/wave": true,
+        "audio/webm": true,
+        "audio/webm;codecs=opus": true,
+        "audio/x-wav": true,
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "text/css": true,
+        "text/csv": true,
+        "text/html": true,
+        "text/javascript": true,
+        "text/markdown": true,
+        "text/plain": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "text/xml": true,
+        "video/audio/s16le": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "video/mp4": true,
+        "video/text/timestamp": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true
+      },
+      "supportsImages": true,
+      "supportsThinking": true,
+      "supportsVideo": true,
+      "tagDescription": "gemini-3.5-flash-lite",
+      "thinkingBudget": -1,
+      "thinkingLevel": 3
     },
     "gemini-3.5-flash-low": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
@@ -803,8 +855,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -892,8 +944,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -981,8 +1033,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1070,8 +1122,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1158,8 +1210,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1239,8 +1291,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1322,8 +1374,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1405,8 +1457,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1487,8 +1539,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1568,8 +1620,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1651,8 +1703,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1734,8 +1786,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1816,8 +1868,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1900,8 +1952,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9715965,
-        "resetTime": "2026-09-05T15:37:39Z"
+        "remainingFraction": 0.9779222,
+        "resetTime": "2026-09-09T10:34:02Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1972,7 +2024,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-05T15:39:57Z"
+        "resetTime": "2026-09-09T10:37:15Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "4.0.64",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.64.tgz",
-      "integrity": "sha512-D8+74xfXkzPi5qCe7iRzQRH/1WW805gBrXfwz7KKEBa0SMY2TENdsTrJnVqFZaT7UYow1Ls6qroaklLd9veU9w==",
+      "version": "4.0.65",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.65.tgz",
+      "integrity": "sha512-W687DtVx59ePCvzv1M8oqCOkSr/gs6wrHlEF/K1UXMHSwB2DuttrSMzXKudaDhwdoiqbCdckvt4efRih1OXHEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.10",
-        "@ai-sdk/provider-utils": "5.0.36"
+        "@ai-sdk/provider": "4.0.11",
+        "@ai-sdk/provider-utils": "5.0.37"
       },
       "engines": {
         "node": ">=22"
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.10.tgz",
-      "integrity": "sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.11.tgz",
+      "integrity": "sha512-A/Cyjma9RLTLsF9xv/2OSaw9eyFhOIBqzoeOVZhp+xKZD8wv5opN+qyIa83NE4Jug2SjQ/Kaf08w1JX6CESR/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -51,12 +51,12 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.36",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.36.tgz",
-      "integrity": "sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ==",
+      "version": "5.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.37.tgz",
+      "integrity": "sha512-WzLQPWtpLpunKBanq/TX8+rbBz7JdKpl8Io4nl/g+bLvePbxMlMuxLrxT8JzquxJmgWKbW4nfFrQ5mnX4A8mpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "4.0.10",
+        "@ai-sdk/provider": "4.0.11",
         "@standard-schema/spec": "^1.1.0",
         "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8",
@@ -729,13 +729,13 @@
       "license": "MIT"
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.29",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.29.tgz",
-      "integrity": "sha512-IhF83EU4I/ASgWwvm0FIh1O3a8ZVuCLqPrCbmSHdSYq7GHxIYe773i6dHqcbrzCzvlG/lP2H+dyTQ+xPAwFpbw==",
+      "version": "1.18.30",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.30.tgz",
+      "integrity": "sha512-bXWcA2VD478PXXke1qAYANTq58fCcbgY0GAUqZIFZqPpo48FoG8RH37nNZ78eHtz+ddiKIhFTBZJRaHF3IgFqw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.29",
+        "@opencode-ai/sdk": "1.18.30",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -778,9 +778,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.29",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.29.tgz",
-      "integrity": "sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A==",
+      "version": "1.18.30",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.30.tgz",
+      "integrity": "sha512-uviJ+PZLc/D1szt33WGzzt/rqJ+IaNmRGBb+UcOXrcQANl8XXKJrp4CNQQ2UAnUJ3Ek+VqcamIwjtKHUW/OjOQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -1553,13 +1553,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -3544,18 +3544,18 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "dev": true,
       "license": "MIT"
     },

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.1.27';
+const AGY_API_VERSION = '1.1.28';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.1.27';
+export const AGY_CLI_VERSION = '1.1.28';


### PR DESCRIPTION
# Description

### CLI & API Version Constants
Update AGY_CLI_VERSION and AGY_API_VERSION to 1.1.28.
Maintain user-agent parity with upstream Antigravity CLI releases.

### Release Configuration
Pin release-as version in release-please configuration to 1.1.28.
Ensure automated changelog and version tags align with target CLI release.

### Model Catalog Refresh
Refresh models.json from live Code Assist endpoint.
Update gemini-3.5-flash-lite internal enum mapping to MODEL_PLACEHOLDER_M198 while preserving backward compatibility rewrites.

### Dependencies
Update semver dependencies in package-lock.json.
Maintain compatibility with latest plugin ecosystem packages.
