### PR TITLE
feat(agy): bump agy CLI to v1.2.1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,7 @@
       "changelog-path": "CHANGELOG.md",
       "skip-github-release": false,
       "include-v-in-tag": false,
-      "release-as": "1.2.0"
+      "release-as": "1.2.1"
     }
   },
   "changelog-sections": [

--- a/models.json
+++ b/models.json
@@ -147,7 +147,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-10T08:33:29Z"
+        "resetTime": "2026-09-11T13:51:47Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -186,7 +186,7 @@
       "modelProvider": "MODEL_PROVIDER_ANTHROPIC",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-10T08:33:29Z"
+        "resetTime": "2026-09-11T13:51:47Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -205,60 +205,234 @@
     },
     "gemini-2.5-flash": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "displayName": "Gemini 3.1 Flash Lite",
+      "displayName": "Gemini 3.5 Flash Lite",
       "maxOutputTokens": 65535,
       "maxTokens": 1048576,
+      "minThinkingBudget": 128,
       "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH",
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
             "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    },\n    \"session_summary_prompt_override\": \"\"\n}"
+          },
+          "retry_model_capacity_exhausted": {
+            "boolValue": true
           }
         }
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
-      }
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
+      },
+      "recommended": true,
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/pdf": true,
+        "application/rtf": true,
+        "application/x-ipynb+json": true,
+        "application/x-javascript": true,
+        "application/x-python-code": true,
+        "application/x-typescript": true,
+        "audio/aac": true,
+        "audio/flac": true,
+        "audio/l16": true,
+        "audio/m4a": true,
+        "audio/mp3": true,
+        "audio/mp4": true,
+        "audio/mpeg": true,
+        "audio/ogg": true,
+        "audio/opus": true,
+        "audio/vnd.wave": true,
+        "audio/wav": true,
+        "audio/wave": true,
+        "audio/webm": true,
+        "audio/webm;codecs=opus": true,
+        "audio/x-wav": true,
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "text/css": true,
+        "text/csv": true,
+        "text/html": true,
+        "text/javascript": true,
+        "text/markdown": true,
+        "text/plain": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "text/xml": true,
+        "video/audio/s16le": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "video/mp4": true,
+        "video/text/timestamp": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true
+      },
+      "supportsImages": true,
+      "supportsThinking": true,
+      "supportsVideo": true,
+      "tagDescription": "gemini-3.5-flash-lite",
+      "thinkingBudget": -1,
+      "thinkingLevel": 3
     },
     "gemini-2.5-flash-lite": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "displayName": "Gemini 3.1 Flash Lite",
+      "displayName": "Gemini 3.5 Flash Lite",
       "maxOutputTokens": 65535,
       "maxTokens": 1048576,
+      "minThinkingBudget": 128,
       "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_LITE",
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
             "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    },\n    \"session_summary_prompt_override\": \"\"\n}"
+          },
+          "retry_model_capacity_exhausted": {
+            "boolValue": true
           }
         }
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
-      }
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
+      },
+      "recommended": true,
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/pdf": true,
+        "application/rtf": true,
+        "application/x-ipynb+json": true,
+        "application/x-javascript": true,
+        "application/x-python-code": true,
+        "application/x-typescript": true,
+        "audio/aac": true,
+        "audio/flac": true,
+        "audio/l16": true,
+        "audio/m4a": true,
+        "audio/mp3": true,
+        "audio/mp4": true,
+        "audio/mpeg": true,
+        "audio/ogg": true,
+        "audio/opus": true,
+        "audio/vnd.wave": true,
+        "audio/wav": true,
+        "audio/wave": true,
+        "audio/webm": true,
+        "audio/webm;codecs=opus": true,
+        "audio/x-wav": true,
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "text/css": true,
+        "text/csv": true,
+        "text/html": true,
+        "text/javascript": true,
+        "text/markdown": true,
+        "text/plain": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "text/xml": true,
+        "video/audio/s16le": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "video/mp4": true,
+        "video/text/timestamp": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true
+      },
+      "supportsImages": true,
+      "supportsThinking": true,
+      "supportsVideo": true,
+      "tagDescription": "gemini-3.5-flash-lite",
+      "thinkingBudget": -1,
+      "thinkingLevel": 3
     },
     "gemini-2.5-flash-thinking": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
-      "displayName": "Gemini 3.1 Flash Lite",
+      "displayName": "Gemini 3.5 Flash Lite",
       "maxOutputTokens": 65535,
       "maxTokens": 1048576,
+      "minThinkingBudget": 128,
       "model": "MODEL_GOOGLE_GEMINI_2_5_FLASH_THINKING",
       "modelExperiments": {
         "experiments": {
           "CASCADE_USE_EXPERIMENT_CHECKPOINTER": {
             "stringValue": "{\n    \"strategy\": \"CHECKPOINT_STRATEGY_SINGLE_PROMPT\",\n    \"max_token_limit\": \"128000\",\n    \"token_threshold\": \"50000\",\n    \"max_overhead_ratio\": \"0.15\",\n    \"moving_window_size\": \"1\",\n    \"enabled\": true,\n    \"max_output_tokens\": \"16384\",\n    \"checkpoint_model\": \"MODEL_PLACEHOLDER_M50\",\n    \"use_last_planner_model\": false,\n    \"is_sync\": false,\n    \"max_user_requests\": 10,\n    \"include_last_user_message\": false,\n    \"include_conversation_log\": true,\n    \"include_running_task_snapshots\": true,\n    \"include_subagent_snapshots\": true,\n    \"include_artifact_snapshots\": true,\n    \"retry_config\": {\n        \"max_retries\": 0,\n        \"initial_sleep_duration_ms\": 1000,\n        \"exponential_multiplier\": 2,\n        \"include_error_feedback\": false\n    },\n    \"session_summary_prompt_override\": \"\"\n}"
+          },
+          "retry_model_capacity_exhausted": {
+            "boolValue": true
           }
         }
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
-      }
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
+      },
+      "recommended": true,
+      "supportedMimeTypes": {
+        "application/json": true,
+        "application/pdf": true,
+        "application/rtf": true,
+        "application/x-ipynb+json": true,
+        "application/x-javascript": true,
+        "application/x-python-code": true,
+        "application/x-typescript": true,
+        "audio/aac": true,
+        "audio/flac": true,
+        "audio/l16": true,
+        "audio/m4a": true,
+        "audio/mp3": true,
+        "audio/mp4": true,
+        "audio/mpeg": true,
+        "audio/ogg": true,
+        "audio/opus": true,
+        "audio/vnd.wave": true,
+        "audio/wav": true,
+        "audio/wave": true,
+        "audio/webm": true,
+        "audio/webm;codecs=opus": true,
+        "audio/x-wav": true,
+        "image/heic": true,
+        "image/heif": true,
+        "image/jpeg": true,
+        "image/png": true,
+        "image/webp": true,
+        "text/css": true,
+        "text/csv": true,
+        "text/html": true,
+        "text/javascript": true,
+        "text/markdown": true,
+        "text/plain": true,
+        "text/rtf": true,
+        "text/x-python": true,
+        "text/x-python-script": true,
+        "text/x-typescript": true,
+        "text/xml": true,
+        "video/audio/s16le": true,
+        "video/audio/wav": true,
+        "video/jpeg2000": true,
+        "video/mp4": true,
+        "video/text/timestamp": true,
+        "video/videoframe/jpeg2000": true,
+        "video/webm": true
+      },
+      "supportsImages": true,
+      "supportsThinking": true,
+      "supportsVideo": true,
+      "tagDescription": "gemini-3.5-flash-lite",
+      "thinkingBudget": -1,
+      "thinkingLevel": 3
     },
     "gemini-2.5-pro": {
       "apiProvider": "API_PROVIDER_GOOGLE_GEMINI",
@@ -276,8 +450,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "requiresImageOutputOutsideFunctionResponses": true,
@@ -351,8 +525,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -426,8 +600,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -490,8 +664,8 @@
       "model": "MODEL_PLACEHOLDER_M21",
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       }
     },
     "gemini-3.1-flash-lite": {
@@ -509,8 +683,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       }
     },
     "gemini-3.1-pro-high": {
@@ -541,8 +715,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -626,8 +800,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -701,8 +875,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -778,8 +952,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -855,8 +1029,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -944,8 +1118,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1033,8 +1207,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1122,8 +1296,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1210,8 +1384,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1291,8 +1465,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1374,8 +1548,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1457,8 +1631,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1539,8 +1713,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1620,8 +1794,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1703,8 +1877,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1786,8 +1960,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1868,8 +2042,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -1952,8 +2126,8 @@
       },
       "modelProvider": "MODEL_PROVIDER_GOOGLE",
       "quotaInfo": {
-        "remainingFraction": 0.9791492,
-        "resetTime": "2026-09-10T08:31:20Z"
+        "remainingFraction": 0.8330518,
+        "resetTime": "2026-09-11T09:16:14Z"
       },
       "recommended": true,
       "supportedMimeTypes": {
@@ -2024,7 +2198,7 @@
       "modelProvider": "MODEL_PROVIDER_OPENAI",
       "quotaInfo": {
         "remainingFraction": 1,
-        "resetTime": "2026-09-10T08:33:29Z"
+        "resetTime": "2026-09-11T13:51:47Z"
       },
       "recommended": true,
       "supportsThinking": true,

--- a/scripts/fetch-models.mjs
+++ b/scripts/fetch-models.mjs
@@ -33,7 +33,7 @@ import { fileURLToPath } from 'node:url';
 const AGY_CLIENT_ID = '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
 const AGY_CLIENT_SECRET = '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';
 const DEFAULT_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
-const AGY_API_VERSION = '1.2.0';
+const AGY_API_VERSION = '1.2.1';
 
 function parseArgs(argv) {
   const args = { endpoint: null, output: null, verbose: false };

--- a/src/sdk/agy-cli-version.ts
+++ b/src/sdk/agy-cli-version.ts
@@ -1,1 +1,1 @@
-export const AGY_CLI_VERSION = '1.2.0';
+export const AGY_CLI_VERSION = '1.2.1';


### PR DESCRIPTION
# Description

### SDK Version Constants
Bump agy CLI version to 1.2.1 across SDK and fetch scripts.
Align user agent header and API protocol version with upstream release.

### Model Catalog
Refresh models catalog against live Code Assist endpoint.
Update pricing, thinking configurations, and remaining quotas.

### Release Configuration
Update release-please configuration target to 1.2.1.
Prepare package metadata for automated changelog and versioning.